### PR TITLE
Leidenspain/Hook Light - Add White to HueSat mode

### DIFF
--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -532,6 +532,13 @@ action:
                     hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) + 15) % 360, 100] }}'
                     transition: 0.25
                   entity_id: !input light
+            - conditions: '{{ light_color_mode_id == "hs_color_white" }}'
+              sequence:
+                - service: light.turn_on
+                  data:
+                    hs_color: '{%- if state_attr(light,"hs_color")[0] > 15 or state_attr(light,"hs_color") == (0,0) -%} {{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }} {%- else -%} [0,0] {%- endif -%}'
+                    transition: 0.25
+                  entity_id: !input light
       - conditions: '{{ action == color_down and light_color_mode_id != "none" }}'
         sequence:
           choose:
@@ -547,6 +554,13 @@ action:
                 - service: light.turn_on
                   data:
                     hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }}'
+                    transition: 0.25
+                  entity_id: !input light
+            - conditions: '{{ light_color_mode_id == "hs_color_white" }}'
+              sequence:
+                - service: light.turn_on
+                  data:
+                    hs_color: '{%- if state_attr(light,"hs_color")[0] > 15 or state_attr(light,"hs_color") == (0,0) -%} {{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }} {%- else -%} [0,0] {%- endif -%}'
                     transition: 0.25
                   entity_id: !input light
       - conditions: '{{ action == color_up_repeat and light_color_mode_id != "none" }}'
@@ -576,6 +590,18 @@ action:
                         entity_id: !input light
                       - delay:
                           milliseconds: 250
+            - conditions: '{{ light_color_mode_id == "hs_color_white" }}'
+              sequence:
+                - repeat:
+                    while: '{{ true }}'
+                    sequence:
+                      - service: light.turn_on
+                        data:
+                          hs_color: '{%- if state_attr(light,"hs_color")[0] < 345 or state_attr(light,"hs_color") == (0,0) -%} {{ [((state_attr(light,"hs_color")[0] or 0) + 15) % 360, 100] }} {%- else -%} [0,0] {%- endif -%}'
+                          transition: 0.25
+                        entity_id: !input light
+                      - delay:
+                          milliseconds: 250
       - conditions: '{{ action == color_down_repeat and light_color_mode_id != "none" }}'
         sequence:
           choose:
@@ -599,6 +625,18 @@ action:
                       - service: light.turn_on
                         data:
                           hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }}'
+                          transition: 0.25
+                        entity_id: !input light
+                      - delay:
+                          milliseconds: 250
+            - conditions: '{{ light_color_mode_id == "hs_color_white" }}'
+              sequence:
+                - repeat:
+                    while: '{{ true }}'
+                    sequence:
+                      - service: light.turn_on
+                        data:
+                          hs_color: '{%- if state_attr(light,"hs_color")[0] > 15 or state_attr(light,"hs_color") == (0,0) -%} {{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }} {%- else -%} [0,0] {%- endif -%}'
                           transition: 0.25
                         entity_id: !input light
                       - delay:

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -77,6 +77,7 @@ blueprint:
             - Auto
             - Color Temperature
             - Hue - Saturation
+            - Hue - Saturation with White
             - None
     light_transition:
       name: (Optional) Light Transition
@@ -338,11 +339,12 @@ variables:
     Auto: auto
     Color Temperature: color_temp
     Hue - Saturation: hs_color
+    Hue - Saturation with White: hs_color_white
     None: none
   # extract light color mode id
   light_color_mode_id: >-
     {%- if light_color_mode == "Auto" -%} {% set supported_color_modes = state_attr(light, "supported_color_modes") -%} {%- if "hs" in supported_color_modes or "xy" in supported_color_modes or "rgbw" in supported_color_modes or "rgbww" in supported_color_modes -%} {{
-    color_modes["Hue - Saturation"] }} {%- elif "color_temp" in supported_color_modes -%} {{ color_modes["Color Temperature"] }} {%- else -%} {{ color_modes["None"] }} {%- endif -%} {%- else -%} {{ color_modes[light_color_mode] }} {%- endif -%}
+    color_modes["Hue - Saturation","Hue - Saturation with White"] }} {%- elif "color_temp" in supported_color_modes -%} {{ color_modes["Color Temperature"] }} {%- else -%} {{ color_modes["None"] }} {%- endif -%} {%- else -%} {{ color_modes[light_color_mode] }} {%- endif -%}
   step_short: '{{ (max_brightness-min_brightness)/brightness_steps_short }}'
   step_long: '{{ (max_brightness-min_brightness)/brightness_steps_long }}'
 mode: restart

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -16,7 +16,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.07.30
+    ℹ️ Version 2023.10.31 (with white mode)
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/hooks/light/light.yaml
   domain: automation
   input:

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -536,7 +536,7 @@ action:
               sequence:
                 - service: light.turn_on
                   data:
-                    hs_color: '{%- if state_attr(light,"hs_color")[0] < 345 or state_attr(light,"hs_color") == (0,0) -%} {{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }} {%- else -%} [0,0] {%- endif -%}'
+                    hs_color: '{%- if state_attr(light,"hs_color")[0] < 345 or state_attr(light,"hs_color") == (0,0) -%} {{ [((state_attr(light,"hs_color")[0] or 0) + 15) % 360, 100] }} {%- else -%} [0,0] {%- endif -%}'
                     transition: 0.25
                   entity_id: !input light
       - conditions: '{{ action == color_down and light_color_mode_id != "none" }}'

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -536,7 +536,7 @@ action:
               sequence:
                 - service: light.turn_on
                   data:
-                    hs_color: '{%- if state_attr(light,"hs_color")[0] > 15 or state_attr(light,"hs_color") == (0,0) -%} {{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }} {%- else -%} [0,0] {%- endif -%}'
+                    hs_color: '{%- if state_attr(light,"hs_color")[0] < 345 or state_attr(light,"hs_color") == (0,0) -%} {{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }} {%- else -%} [0,0] {%- endif -%}'
                     transition: 0.25
                   entity_id: !input light
       - conditions: '{{ action == color_down and light_color_mode_id != "none" }}'


### PR DESCRIPTION
## Breaking change

Designed not to be breaking change, Hue+Sat with White mode has been added as extra selection.
This should remain compatible for current users

## Proposed change\*

As a user cycles through the Hue+Sat wheel using the remote, One Step before or after true red is true white.

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.

## To Do