### PR TITLE
Add Clamping of Color Temperature to Light Blueprint

### DIFF
--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -163,6 +163,34 @@ blueprint:
       default: true
       selector:
         boolean:
+    enable_clamp_color_temp:
+      name: (Optional) Enable clamping color temperature
+      description: Enable clamping of color temperature (i.e. enforcing min and max values)
+      default: false
+      selector:
+        boolean:
+    min_color_temp:
+      name: (Optional) Light minimum color temperature
+      description: The minimum color temperature the light can be set with this automation. Will only take an effect if the light color mode evaluates to "Color Temperature" and clamping of color temperature is enabled.
+      default: 153
+      selector:
+        number:
+          min: 100
+          max: 750
+          step: 1
+          unit_of_measurement: mired
+          mode: slider
+    max_color_temp:
+      name: (Optional) Light maximum color temperature
+      description: The maximum color temperature the light can be set with this automation. Will only take an effect if the light color mode evaluates to "Color Temperature" and clamping of color temperature is enabled.
+      default: 500
+      selector:
+        number:
+          min: 100
+          max: 750
+          step: 1
+          unit_of_measurement: mired
+          mode: slider
 # Automation schema
 variables:
   # convert blueprint inputs into variables to be used in templates
@@ -344,6 +372,9 @@ variables:
   on_brightness: !input on_brightness
   smooth_power_on: !input smooth_power_on
   smooth_power_off: !input smooth_power_off
+  enable_clamp_color_temp: !input enable_clamp_color_temp
+  min_color_temp: !input min_color_temp
+  max_color_temp: !input max_color_temp
   color_modes:
     Auto: auto
     Color Temperature: color_temp
@@ -526,6 +557,13 @@ action:
       - conditions: '{{ action == color_up and light_color_mode_id != "none" }}'
         sequence:
           choose:
+            - conditions: '{{ light_color_mode_id == "color_temp" and enable_clamp_color_temp }}'
+              sequence:
+                - service: light.turn_on
+                  data:
+                    color_temp: '{{ [ [state_attr(light,"color_temp")|int + 50, min_color_temp] | max, max_color_temp] | min }}'
+                    transition: 0.25
+                  entity_id: !input light
             - conditions: '{{ light_color_mode_id == "color_temp" }}'
               sequence:
                 - service: light.turn_on
@@ -543,6 +581,13 @@ action:
       - conditions: '{{ action == color_down and light_color_mode_id != "none" }}'
         sequence:
           choose:
+            - conditions: '{{ light_color_mode_id == "color_temp" and enable_clamp_color_temp }}'
+              sequence:
+                - service: light.turn_on
+                  data:
+                    color_temp: '{{ [ [state_attr(light,"color_temp")|int - 50, min_color_temp] | max, max_color_temp] | min }}'
+                    transition: 0.25
+                  entity_id: !input light
             - conditions: '{{ light_color_mode_id == "color_temp" }}'
               sequence:
                 - service: light.turn_on
@@ -560,6 +605,18 @@ action:
       - conditions: '{{ action == color_up_repeat and light_color_mode_id != "none" }}'
         sequence:
           choose:
+            - conditions: '{{ light_color_mode_id == "color_temp" and enable_clamp_color_temp }}'
+              sequence:
+                - repeat:
+                    while: '{{ true }}'
+                    sequence:
+                      - service: light.turn_on
+                        data:
+                          color_temp: '{{ [ [state_attr(light,"color_temp")|int + 50, min_color_temp] | max, max_color_temp] | min }}'
+                          transition: 0.25
+                        entity_id: !input light
+                      - delay:
+                          milliseconds: 250
             - conditions: '{{ light_color_mode_id == "color_temp" }}'
               sequence:
                 - repeat:
@@ -587,7 +644,19 @@ action:
       - conditions: '{{ action == color_down_repeat and light_color_mode_id != "none" }}'
         sequence:
           choose:
-            - conditions: '{{ light_color_mode_id == "color_temp" }}'
+            - conditions: '{{ light_color_mode_id == "color_temp" and enable_clamp_color_temp }}'
+              sequence:
+                - repeat:
+                    while: '{{ true }}'
+                    sequence:
+                      - service: light.turn_on
+                        data:
+                          color_temp: '{{ [ [state_attr(light,"color_temp")|int - 50, min_color_temp] | max, max_color_temp] | min }}'
+                          transition: 0.25
+                        entity_id: !input light
+                      - delay:
+                          milliseconds: 250
+            - conditions: '{{ light_color_mode_id == "color_temp"}}'
               sequence:
                 - repeat:
                     while: '{{ true }}'

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -176,7 +176,7 @@ blueprint:
       selector:
         number:
           min: 100
-          max: 750
+          max: 600
           step: 1
           unit_of_measurement: mired
           mode: slider
@@ -187,7 +187,7 @@ blueprint:
       selector:
         number:
           min: 100
-          max: 750
+          max: 600
           step: 1
           unit_of_measurement: mired
           mode: slider

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -165,7 +165,7 @@ blueprint:
         boolean:
     enable_clamp_color_temp:
       name: (Optional) Enable clamping color temperature
-      description: Enable clamping of color temperature (i.e. enforcing min and max values)
+      description: Enable clamping of color temperature (i.e. enforcing min and max values).
       default: false
       selector:
         boolean:

--- a/website/docs/blueprints/hooks/light.mdx
+++ b/website/docs/blueprints/hooks/light.mdx
@@ -19,7 +19,7 @@ This Hook blueprint allows to build a controller-based automation to control a l
 :::info
 An automation created with this blueprint must be linked to a [Controller](/docs/blueprints/controllers) automation. Controllers are blueprints which allow to easily integrate a wide range of controllers and use them to run a set of actions when interacting with them. They expose an abstract interface used by Hooks to create controller-based automations.
 
-See the list of [Controllers supported by this Hook](#supported-controllers) for additional details.
+See the list of [Controllers supported by this Hook]( #supported-controllers) for additional details.
 :::
 
 ## Requirements
@@ -36,78 +36,93 @@ This integration provides the entity which represents a light in Home Assistant.
 ## Inputs
 
 <Input
-  name='Controller Device'
-  description='The controller device which will control the Light. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as a Device. This value should match the one specified in the corresponding Controller automation.'
-  selector='device'
-  required
+name='Controller Device'
+description='The controller device which will control the Light. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as a Device. This value should match the one specified in the corresponding Controller automation.'
+selector='device'
+required
 />
 <Input
-  name='Controller Entity'
-  description='The controller entity which will control the Light. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as an Entity. This value should match the one specified in the corresponding Controller automation.'
-  selector='entity'
-  required
+name='Controller Entity'
+description='The controller entity which will control the Light. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as an Entity. This value should match the one specified in the corresponding Controller automation.'
+selector='entity'
+required
 />
 <Input
-  name='Controller model'
-  description='The model for the controller used in this automation. Choose a value from the list of supported controllers.'
-  selector='select'
-  required
+name='Controller model'
+description='The model for the controller used in this automation. Choose a value from the list of supported controllers.'
+selector='select'
+required
 />
 <Input
-  name='Light'
-  description='Light which will be controlled with this automation.'
-  selector='entity'
-  required
+name='Light'
+description='Light which will be controlled with this automation.'
+selector='entity'
+required
 />
 <Input
-  name='Light color mode'
-  description='Specify how the controller will set the light color. Choose "Color Temperature" and "Hue - Saturation" depending on the features supported by your light. If you are not sure you can select "Auto". "None" will disable color control features.'
-  selector='select'
+name='Light color mode'
+description='Specify how the controller will set the light color. Choose "Color Temperature" and "Hue - Saturation" depending on the features supported by your light. If you are not sure you can select "Auto". "None" will disable color control features.'
+selector='select'
 />
 <Input
-  name='Light Transition'
-  description='Number that represents the time (in milliseconds) the light should take turn on or off, if the light supports it.'
-  selector='number'
+name='Light Transition'
+description='Number that represents the time (in milliseconds) the light should take turn on or off, if the light supports it.'
+selector='number'
 />
 <Input
-  name='Light minimum brightness'
-  description='The minimum brightness the light can be set with this automation.'
-  selector='number'
+name='Light minimum brightness'
+description='The minimum brightness the light can be set with this automation.'
+selector='number'
 />
 <Input
-  name='Light maximum brightness'
-  description='The maximum brightness the light can be set with this automation.'
-  selector='number'
+name='Light maximum brightness'
+description='The maximum brightness the light can be set with this automation.'
+selector='number'
 />
 <Input
-  name='Light brightness steps - short actions'
-  description='Number of steps from min to max brightness when controlling brightness with short actions (eg. button press).'
-  selector='number'
+name='Light brightness steps - short actions'
+description='Number of steps from min to max brightness when controlling brightness with short actions (eg. button press).'
+selector='number'
 />
 <Input
-  name='Light brightness steps - long actions'
-  description='Number of steps from min to max brightness when controlling brightness with long actions (eg. button hold or controller rotation).'
-  selector='number'
+name='Light brightness steps - long actions'
+description='Number of steps from min to max brightness when controlling brightness with long actions (eg. button hold or controller rotation).'
+selector='number'
 />
 <Input
-  name='Force brightness value at turn on'
-  description='Force brightness to the "On brightness" input value, when the light is being turned on.'
-  selector='boolean'
+name='Force brightness value at turn on'
+description='Force brightness to the "On brightness" input value, when the light is being turned on.'
+selector='boolean'
 />
 <Input
-  name='On brightness'
-  description='Brightness value to force when turning on the light'
-  selector='number'
+name='On brightness'
+description='Brightness value to force when turning on the light'
+selector='number'
 />
 <Input
-  name='Smooth power on'
-  description='Force the light to turn on at minimum brightness when a brightness up command (single or continuous) is triggered and light is off.'
-  selector='boolean'
+name='Smooth power on'
+description='Force the light to turn on at minimum brightness when a brightness up command (single or continuous) is triggered and light is off.'
+selector='boolean'
 />
 <Input
-  name='Smooth power off'
-  description='Allow a brightness down command (single or continuous) to turn off the light when at minimum brightness. Disabling this will prevent the light from being turned off by brightness down commands.'
-  selector='boolean'
+name='Smooth power off'
+description='Allow a brightness down command (single or continuous) to turn off the light when at minimum brightness. Disabling this will prevent the light from being turned off by brightness down commands.'
+selector='boolean'
+/>
+<Input
+name='Enable clamping color temperature'
+description='Enable clamping of color temperature (i.e. enforcing min and max values).'
+selector='boolean'
+/>
+<Input
+name='Light minimum color temperature'
+description='The minimum color temperature the light can be set with this automation. Will only take an effect if the light color mode evaluates to "Color Temperature" and clamping of color temperature is enabled.'
+selector='number'
+/>
+<Input
+name='Light maximum color temperature'
+description='The maximum color temperature the light can be set with this automation. Will only take an effect if the light color mode evaluates to "Color Temperature" and clamping of color temperature is enabled.'
+selector='number'
 />
 
 ## Supported Controllers
@@ -141,31 +156,31 @@ If you want to link multiple lights to the same controller you can either use [L
 - **2021-03-14**: add support for IKEA E1812 Shortcut button, fix E1743 naming
 - **2021-03-25**: update action mapping for IKEA E1744. If you're using this Hook with an IKEA E1744, please update also the corresponding Controller blueprint
 - **2021-03-26**:
-  - set minimum and maximum light brightness
-  - specify number of steps from min to max brightness, both for short and long actions, when controlling the light
-  - allow to force brightness to a specific value when turning on the light
+- set minimum and maximum light brightness
+- specify number of steps from min to max brightness, both for short and long actions, when controlling the light
+- allow to force brightness to a specific value when turning on the light
 - **2021-03-27**: add support for Philips Hue dimmer switch
 - **2021-04-06**: fix light color modes not allowing to configure an automation with color temperature control.
 - **2021-04-15**:
-  - add smooth power on/off features
-  - **breaking change**: by default the light now turns off when a brightness down command is received and light is at minimum brightness. To disable this behaviour, turn off the smooth power off feature.
-  - fix some optional fields name.
+- add smooth power on/off features
+- **breaking change**: by default the light now turns off when a brightness down command is received and light is at minimum brightness. To disable this behaviour, turn off the smooth power off feature.
+- fix some optional fields name.
 - **2021-04-19**: remove unused variable, fix warnings for undefined variables in Home Assistant Core >=2021.4.0
 - **2021-05-16**: Add support for Osram SMART+ Switch Mini
 - **2021-07-03**: Add support for Philips Hue Smart Button
 - **2021-08-02**: Improve inputs documentation and organization
 - **2021-10-26**:
-  - Standardize blueprints structure and inputs naming across the whole collection.
-  - Improve blueprint documentation.
-  - :tada: Add support for alternate mappings. Additional mappings for currently supported controllers will be added from now on. Refer to the documentation of your controller for more details.
-  - :warning: **Breaking Change**: update controller names in the `Controller Model` input, to match the full name of controllers, prevent ambiguities and enable support for alternate mappings. After updating this blueprint, please reconfigure your automations by selecting again the value for the `Controller Model` input, matching the full name of the controller you're using with this hook.
-  - Fix for remembering brightness level when turning on, where brightness level unavailable when light off.
-  - Added secondary mapping for IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+- Standardize blueprints structure and inputs naming across the whole collection.
+- Improve blueprint documentation.
+- :tada: Add support for alternate mappings. Additional mappings for currently supported controllers will be added from now on. Refer to the documentation of your controller for more details.
+- :warning: **Breaking Change**: update controller names in the `Controller Model` input, to match the full name of controllers, prevent ambiguities and enable support for alternate mappings. After updating this blueprint, please reconfigure your automations by selecting again the value for the `Controller Model` input, matching the full name of the controller you're using with this hook.
+- Fix for remembering brightness level when turning on, where brightness level unavailable when light off.
+- Added secondary mapping for IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
 - **2021-10-29**: Add support for IKEA E1766 TRÅDFRI Open/Close Remote.
 - **2021-11-07**:
-  - Add support for IKEA E2001/E2002 STYRBAR Remote control.
-  - Fix color mode automatic detection not working properly with color temperature lights.
-  - Add "None" color mode to completely disable color control features.
+- Add support for IKEA E2001/E2002 STYRBAR Remote control.
+- Fix color mode automatic detection not working properly with color temperature lights.
+- Add "None" color mode to completely disable color control features.
 - **2021-11-21**: Add support for Philips 929002398602 Hue Dimmer switch v2.
 - **2021-12-03**: Add support for Xiaomi WXCJKG11LM, WXCJKG12LM, WXCJKG13LM.
 - **2021-12-05**: Added secondary mapping for IKEA E2001/E2002


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

In its current version the light hook allows the color temperature to be changed to values that are not support by the light bulbs. Reaching values far outside this range will require the user to press the opposite button, potentially overshooting in the other direction.

I added a clamping mechanism similar to the brightness minimum and maximum. Additionally, I added a feature toggle that is deactivated by default, in order to prevent any breaking changes.

I had a look at a couple of example light bulbs, here are their valid color temperature ranges:
- [Innr RB 279 T](https://www.zigbee2mqtt.io/devices/RB_279_T.html): [153, 555]
- [Philips 9290022169] (https://www.zigbee2mqtt.io/devices/9290022169.html): [150, 500]
- [LEDVANCE AC25704](https://www.zigbee2mqtt.io/devices/AC25704.html): [150, 500]

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.

NOTE: I did not commit the result of formatting, because it changed quit a lot of files. Either my formatting is not setup correctly or the code has not been formatted recently. However, none of my changes were changed by formatting :) 
