### PR TITLE
Update ikea_e2001_e2002.yaml, add trigger_action "unknown"

### DIFF
--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -18,9 +18,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints fork](https://github.com/lsismeiro/awesome-ha-blueprints) **.
 
-    ℹ️ Version 2023.10.30
-    Includes fixes for button actions and space evaluation post 2023.5.0
-    Includes fixes for button down hold actions [since 2023-06-11](https://community.home-assistant.io/t/zha-deconz-zigbee2mqtt-ikea-e2001-e2002-styrbar-remote-control-universal-blueprint-all-actions-double-click-events-control-lights-media-players-and-more-with-hooks/354176/109)
+    ℹ️ Version 2024-12-07
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
   domain: automation
   input:

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -387,7 +387,7 @@ condition:
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
         {%- endset -%}
-        {{ trigger_action not in ["","None"] }}
+        {{ trigger_action not in ["","None","unknown"] }}
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'


### PR DESCRIPTION
Exclude trigger_action "unknown" which is being sent by my Styrbar Controller after sending other commands like "on" or "off". Without this change single presses are not recognized correctly when double presses are enabled.

Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

After one of the recent updates (unfortunately I don't know if this was an update to HA or zigbee2mqtt) single presses stopped working when double presses were enabled. I found out that the helper contained the string "unknown" after states like "on" or "off" and figured out this was the reason for my issue. My PR just adds "unknown" to the excluded states like "" and "None".

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
