### PR TITLE
Added Support for IKEA RODRET wireless dimmer/power switch (E2201)

### DIFF
--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -3,23 +3,23 @@ blueprint:
   homeassistant:
     min_version: 2023.6.0
   author: yarafie
-  name: Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+  name: Controller - IKEA E2201 RODRET Dimmer
   description: |
-    # Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+    # Controller - IKEA E2201 RODRET Dimmer 
 
-    Controller automation for executing any kind of action triggered by the provided IKEA E1743 TRÅDFRI On/Off Switch & Dimmer. Allows to optionally loop an action on a button long press.
+    Controller automation for executing any kind of action triggered by the provided IKEA E2201 RODRET Dimmer. Allows to optionally loop an action on a button long press.
     Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
-    See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1743#available-hooks) for additional details.
+    See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e2201#available-hooks) for additional details.
 
-    📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1743).
+    📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e2201).
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2023.10.05
-  source_url: https://raw.githubusercontent.com/lsismeiro/awesome-ha-blueprints/refs/heads/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+  source_url: https://raw.githubusercontent.com/lsismeiro/awesome-ha-blueprints/refs/heads/main/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
   domain: automation
   input:
     integration:
@@ -51,7 +51,7 @@ blueprint:
          filter:
          - integration: mqtt
            manufacturer: IKEA
-           model: TRADFRI on/off switch (E1743)
+           model: RODRET wireless dimmer/power switch (E2201)
          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event

--- a/blueprints/hooks/cover/cover.yaml
+++ b/blueprints/hooks/cover/cover.yaml
@@ -41,6 +41,7 @@ blueprint:
           options:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+            - IKEA E2201 RODRET Dimmer
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1812 TRÅDFRI Shortcut button
             - SONOFF SNZB-01 Wireless Switch
@@ -70,6 +71,12 @@ variables:
       open_cover_tilt: button_right_short
       stop_cover_all: button_center_short
     IKEA E1743 TRÅDFRI On/Off Switch & Dimmer:
+      open_cover: button_up_short
+      open_cover_tilt: button_up_long
+      close_cover: button_down_short
+      close_cover_tilt: button_down_long
+      stop_cover_all: button_down_double
+    IKEA E2201 RODRET Dimmer:
       open_cover: button_up_short
       open_cover_tilt: button_up_long
       close_cover: button_down_short

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -17,77 +17,102 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2022.07.30
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/hooks/light/light.yaml
+  source_url: https://raw.githubusercontent.com/lsismeiro/awesome-ha-blueprints/refs/heads/main/blueprints/hooks/light/light.yaml
   domain: automation
   input:
     controller_device:
       name: (Required) Controller Device
-      description: The controller device which will control the Light. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as a Device. This value should match the one specified in the corresponding Controller automation.
+      description: The controller device which will control the Light. Choose a value
+        only if the integration used to connect the controller to Home Assistant exposes
+        it as a Device. This value should match the one specified in the corresponding
+        Controller automation.
+      default: ''
+      selector:
+        device: {}
+    controller_entity:
+      name: (Required) Controller Entity
+      description: The controller entity which will control the Light. Choose a value
+        only if the integration used to connect the controller to Home Assistant exposes
+        it as an Entity. This value should match the one specified in the corresponding
+        Controller automation.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Required) Controller Entity
-      description: The controller entity which will control the Light. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as an Entity. This value should match the one specified in the corresponding Controller automation.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+         filter:
+         - integration: mqtt
+           manufacturer: IKEA
+           model: RODRET wireless dimmer/power switch (E2201)
+         multiple: false
     controller_model:
       name: (Required) Controller model
-      description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
+      description: The model for the controller used in this automation. Choose a
+        value from the list of supported controllers.
       selector:
         select:
           options:
-            - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
-            - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
-            - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer (#2)
-            - IKEA E1744 SYMFONISK Rotary Remote
-            - IKEA E1766 TRÅDFRI Open/Close Remote
-            - IKEA E1766 TRÅDFRI Open/Close Remote (#2)
-            - IKEA E1812 TRÅDFRI Shortcut button
-            - IKEA E2001/E2002 STYRBAR Remote control
-            - IKEA E2001/E2002 STYRBAR Remote control (#2)
-            - IKEA ICTC-G-1 TRÅDFRI wireless dimmer
-            - OSRAM AC025XX00NJ SMART+ Switch Mini
-            - Philips 324131092621 Hue Dimmer switch
-            - Philips 324131137411 Hue Dimmer switch
-            - Philips 8718699693985 Hue Smart Button
-            - Philips 929002398602 Hue Dimmer switch v2
-            - SONOFF SNZB-01 Wireless Switch
-            - Xiaomi WXCJKG11LM Aqara Opple 2 button remote
-            - Xiaomi WXCJKG12LM Aqara Opple 4 button remote
-            - Xiaomi WXCJKG12LM Aqara Opple 4 button remote (#2)
-            - Xiaomi WXCJKG13LM Aqara Opple 6 button remote
-            - Xiaomi WXCJKG13LM Aqara Opple 6 button remote (#2)
-            - Xiaomi WXCJKG13LM Aqara Opple 6 button remote (#3)
-            - Xiaomi WXKG11LM Aqara Wireless Switch Mini
+          - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
+          - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+          - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer (#2)
+          - IKEA E2201 RODRET Dimmer
+          - IKEA E2201 RODRET Dimmer (#2)
+          - IKEA E1744 SYMFONISK Rotary Remote
+          - IKEA E1766 TRÅDFRI Open/Close Remote
+          - IKEA E1766 TRÅDFRI Open/Close Remote (#2)
+          - IKEA E1812 TRÅDFRI Shortcut button
+          - IKEA E2001/E2002 STYRBAR Remote control
+          - IKEA E2001/E2002 STYRBAR Remote control (#2)
+          - IKEA ICTC-G-1 TRÅDFRI wireless dimmer
+          - OSRAM AC025XX00NJ SMART+ Switch Mini
+          - Philips 324131092621 Hue Dimmer switch
+          - Philips 324131137411 Hue Dimmer switch
+          - Philips 8718699693985 Hue Smart Button
+          - Philips 929002398602 Hue Dimmer switch v2
+          - SONOFF SNZB-01 Wireless Switch
+          - Xiaomi WXCJKG11LM Aqara Opple 2 button remote
+          - Xiaomi WXCJKG12LM Aqara Opple 4 button remote
+          - Xiaomi WXCJKG12LM Aqara Opple 4 button remote (#2)
+          - Xiaomi WXCJKG13LM Aqara Opple 6 button remote
+          - Xiaomi WXCJKG13LM Aqara Opple 6 button remote (#2)
+          - Xiaomi WXCJKG13LM Aqara Opple 6 button remote (#3)
+          - Xiaomi WXKG11LM Aqara Wireless Switch Mini
+          multiple: false
+          custom_value: false
+          sort: false
     light:
       name: (Required) Light
       description: Light which will be controlled with this automation.
       selector:
         entity:
-          domain: light
+          domain:
+          - light
+          multiple: false
     light_color_mode:
       name: (Optional) Light color mode
-      description: Specify how the controller will set the light color. Choose "Color Temperature" and "Hue - Saturation" depending on the features supported by your light. If you are not sure you can select "Auto". "None" will disable color control features.
+      description: Specify how the controller will set the light color. Choose "Color
+        Temperature" and "Hue - Saturation" depending on the features supported by
+        your light. If you are not sure you can select "Auto". "None" will disable
+        color control features.
       default: Auto
       selector:
         select:
           options:
-            - Auto
-            - Color Temperature
-            - Hue - Saturation
-            - None
+          - Auto
+          - Color Temperature
+          - Hue - Saturation
+          - None
+          multiple: false
+          custom_value: false
+          sort: false
     light_transition:
       name: (Optional) Light Transition
-      description: Number that represents the time (in milliseconds) the light should take turn on or off, if the light supports it.
+      description: Number that represents the time (in milliseconds) the light should
+        take turn on or off, if the light supports it.
       default: 250
       selector:
         number:
-          min: 0
-          max: 60000
-          step: 1
+          min: 0.0
+          max: 60000.0
+          step: 1.0
           unit_of_measurement: milliseconds
           mode: box
     min_brightness:
@@ -96,9 +121,9 @@ blueprint:
       default: 1
       selector:
         number:
-          min: 1
-          max: 255
-          step: 1
+          min: 1.0
+          max: 255.0
+          step: 1.0
           unit_of_measurement: brightness
           mode: slider
     max_brightness:
@@ -107,95 +132,103 @@ blueprint:
       default: 255
       selector:
         number:
-          min: 0
-          max: 255
-          step: 1
+          min: 0.0
+          max: 255.0
+          step: 1.0
           unit_of_measurement: brightness
           mode: slider
     brightness_steps_short:
       name: (Optional) Light brightness steps - short actions
-      description: Number of steps from min to max brightness when controlling brightness with short actions (eg. button press).
+      description: Number of steps from min to max brightness when controlling brightness
+        with short actions (eg. button press).
       default: 10
       selector:
         number:
-          min: 1
-          max: 255
-          step: 1
+          min: 1.0
+          max: 255.0
+          step: 1.0
           unit_of_measurement: steps
           mode: box
     brightness_steps_long:
       name: (Optional) Light brightness steps - long actions
-      description: Number of steps from min to max brightness when controlling brightness with long actions (eg. button hold or controller rotation).
+      description: Number of steps from min to max brightness when controlling brightness
+        with long actions (eg. button hold or controller rotation).
       default: 10
       selector:
         number:
-          min: 1
-          max: 255
-          step: 1
+          min: 1.0
+          max: 255.0
+          step: 1.0
           unit_of_measurement: steps
           mode: box
     force_brightness:
       name: (Optional) Force brightness value at turn on
-      description: Force brightness to the "On brightness" input value, when the light is being turned on.
+      description: Force brightness to the "On brightness" input value, when the light
+        is being turned on.
       default: false
       selector:
-        boolean:
+        boolean: {}
     on_brightness:
       name: (Optional) On brightness
       description: Brightness value to force when turning on the light
       default: 1
       selector:
         number:
-          min: 0
-          max: 255
-          step: 1
+          min: 0.0
+          max: 255.0
+          step: 1.0
           unit_of_measurement: brightness
           mode: slider
     smooth_power_on:
       name: (Optional) Smooth power on
-      description: Force the light to turn on at minimum brightness when a brightness up command (single or continuous) is triggered and light is off.
+      description: Force the light to turn on at minimum brightness when a brightness
+        up command (single or continuous) is triggered and light is off.
       default: true
       selector:
-        boolean:
+        boolean: {}
     smooth_power_off:
       name: (Optional) Smooth power off
-      description: Allow a brightness down command (single or continuous) to turn off the light when at minimum brightness. Disabling this will prevent the light from being turned off by brightness down commands.
+      description: Allow a brightness down command (single or continuous) to turn
+        off the light when at minimum brightness. Disabling this will prevent the
+        light from being turned off by brightness down commands.
       default: true
       selector:
-        boolean:
+        boolean: {}
     enable_clamp_color_temp:
       name: (Optional) Enable clamping color temperature
-      description: Enable clamping of color temperature (i.e. enforcing min and max values).
+      description: Enable clamping of color temperature (i.e. enforcing min and max
+        values).
       default: false
       selector:
-        boolean:
+        boolean: {}
     min_color_temp:
       name: (Optional) Light minimum color temperature
-      description: The minimum color temperature the light can be set with this automation. Will only take an effect if the light color mode evaluates to "Color Temperature" and clamping of color temperature is enabled.
+      description: The minimum color temperature the light can be set with this automation.
+        Will only take an effect if the light color mode evaluates to "Color Temperature"
+        and clamping of color temperature is enabled.
       default: 153
       selector:
         number:
-          min: 100
-          max: 600
-          step: 1
+          min: 100.0
+          max: 600.0
+          step: 1.0
           unit_of_measurement: mired
           mode: slider
     max_color_temp:
       name: (Optional) Light maximum color temperature
-      description: The maximum color temperature the light can be set with this automation. Will only take an effect if the light color mode evaluates to "Color Temperature" and clamping of color temperature is enabled.
+      description: The maximum color temperature the light can be set with this automation.
+        Will only take an effect if the light color mode evaluates to "Color Temperature"
+        and clamping of color temperature is enabled.
       default: 500
       selector:
         number:
-          min: 100
-          max: 600
-          step: 1
+          min: 100.0
+          max: 600.0
+          step: 1.0
           unit_of_measurement: mired
           mode: slider
-# Automation schema
 variables:
-  # convert blueprint inputs into variables to be used in templates
   controller_model: !input controller_model
-  # supported controllers and mappings
   controller_mapping:
     IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote:
       brightness_up: button_up_short
@@ -215,6 +248,20 @@ variables:
       brightness_down_repeat: button_down_long
       color_down: button_down_double
     IKEA E1743 TRÅDFRI On/Off Switch & Dimmer (#2):
+      brightness_up: button_up_short
+      brightness_up_repeat: button_up_long
+      turn_on: button_up_double
+      brightness_down: button_down_short
+      brightness_down_repeat: button_down_long
+      turn_off: button_down_double
+    IKEA E2201 RODRET Dimmer:
+      turn_on: button_up_short
+      brightness_up_repeat: button_up_long
+      color_up: button_up_double
+      turn_off: button_down_short
+      brightness_down_repeat: button_down_long
+      color_down: button_down_double
+    IKEA E2201 RODRET Dimmer (#2):
       brightness_up: button_up_short
       brightness_up_repeat: button_up_long
       turn_on: button_up_double
@@ -348,16 +395,21 @@ variables:
     Xiaomi WXKG11LM Aqara Wireless Switch Mini:
       toggle: button_short
       color_up: button_double
-  # pre-choose actions for buttons based on configured controller
-  # no need to perform this task at automation runtime
-  brightness_up: '{{ controller_mapping[controller_model]["brightness_up"] | default(None) }}'
-  brightness_up_repeat: '{{ controller_mapping[controller_model]["brightness_up_repeat"] | default(None) }}'
-  brightness_down: '{{ controller_mapping[controller_model]["brightness_down"] | default(None) }}'
-  brightness_down_repeat: '{{ controller_mapping[controller_model]["brightness_down_repeat"] | default(None) }}'
+  brightness_up: '{{ controller_mapping[controller_model]["brightness_up"] | default(None)
+    }}'
+  brightness_up_repeat: '{{ controller_mapping[controller_model]["brightness_up_repeat"]
+    | default(None) }}'
+  brightness_down: '{{ controller_mapping[controller_model]["brightness_down"] | default(None)
+    }}'
+  brightness_down_repeat: '{{ controller_mapping[controller_model]["brightness_down_repeat"]
+    | default(None) }}'
   color_up: '{{ controller_mapping[controller_model]["color_up"] | default(None) }}'
-  color_up_repeat: '{{ controller_mapping[controller_model]["color_up_repeat"] | default(None) }}'
-  color_down: '{{ controller_mapping[controller_model]["color_down"] | default(None) }}'
-  color_down_repeat: '{{ controller_mapping[controller_model]["color_down_repeat"] | default(None) }}'
+  color_up_repeat: '{{ controller_mapping[controller_model]["color_up_repeat"] | default(None)
+    }}'
+  color_down: '{{ controller_mapping[controller_model]["color_down"] | default(None)
+    }}'
+  color_down_repeat: '{{ controller_mapping[controller_model]["color_down_repeat"]
+    | default(None) }}'
   toggle: '{{ controller_mapping[controller_model]["toggle"] | default(None) }}'
   turn_on: '{{ controller_mapping[controller_model]["turn_on"] | default(None) }}'
   turn_off: '{{ controller_mapping[controller_model]["turn_off"] | default(None) }}'
@@ -380,303 +432,312 @@ variables:
     Color Temperature: color_temp
     Hue - Saturation: hs_color
     None: none
-  # extract light color mode id
-  light_color_mode_id: >-
-    {%- if light_color_mode == "Auto" -%} {% set supported_color_modes = state_attr(light, "supported_color_modes") -%} {%- if "hs" in supported_color_modes or "xy" in supported_color_modes or "rgbw" in supported_color_modes or "rgbww" in supported_color_modes -%} {{
-    color_modes["Hue - Saturation"] }} {%- elif "color_temp" in supported_color_modes -%} {{ color_modes["Color Temperature"] }} {%- else -%} {{ color_modes["None"] }} {%- endif -%} {%- else -%} {{ color_modes[light_color_mode] }} {%- endif -%}
+  light_color_mode_id: '{%- if light_color_mode == "Auto" -%} {% set supported_color_modes
+    = state_attr(light, "supported_color_modes") -%} {%- if "hs" in supported_color_modes
+    or "xy" in supported_color_modes or "rgbw" in supported_color_modes or "rgbww"
+    in supported_color_modes -%} {{ color_modes["Hue - Saturation"] }} {%- elif "color_temp"
+    in supported_color_modes -%} {{ color_modes["Color Temperature"] }} {%- else -%}
+    {{ color_modes["None"] }} {%- endif -%} {%- else -%} {{ color_modes[light_color_mode]
+    }} {%- endif -%}'
   step_short: '{{ (max_brightness-min_brightness)/brightness_steps_short }}'
   step_long: '{{ (max_brightness-min_brightness)/brightness_steps_long }}'
 mode: restart
 max_exceeded: silent
 trigger:
-  - platform: event
-    event_type: ahb_controller_event
-    event_data:
-      controller: !input controller_device
-  - platform: event
-    event_type: ahb_controller_event
-    event_data:
-      controller: !input controller_entity
+- platform: event
+  event_type: ahb_controller_event
+  event_data:
+    controller: !input controller_device
+- platform: event
+  event_type: ahb_controller_event
+  event_data:
+    controller: !input controller_entity
 condition: []
 action:
-  - variables:
-      action: '{{ trigger.event.data.action }}'
-  - choose:
-      - conditions: '{{ action == toggle }}'
+- variables:
+    action: '{{ trigger.event.data.action }}'
+- choose:
+  - conditions: '{{ action == toggle }}'
+    sequence:
+    - choose:
+      - conditions: '{{ force_brightness }}'
         sequence:
-          - choose:
-              - conditions: '{{ force_brightness }}'
-                sequence:
-                  - service: light.toggle
-                    entity_id: !input light
-                    data:
-                      brightness: !input on_brightness
-                      transition: '{{ light_transition / 1000 }}'
-            default:
-              - service: light.toggle
-                entity_id: !input light
-                data:
-                  transition: '{{ light_transition / 1000 }}'
-      - conditions: '{{ action == turn_on }}'
+        - service: light.toggle
+          entity_id: !input light
+          data:
+            brightness: !input on_brightness
+            transition: '{{ light_transition / 1000 }}'
+      default:
+      - service: light.toggle
+        entity_id: !input light
+        data:
+          transition: '{{ light_transition / 1000 }}'
+  - conditions: '{{ action == turn_on }}'
+    sequence:
+    - choose:
+      - conditions: '{{ force_brightness }}'
         sequence:
-          - choose:
-              - conditions: '{{ force_brightness }}'
-                sequence:
-                  - service: light.turn_on
-                    entity_id: !input light
-                    data:
-                      brightness: !input on_brightness
-                      transition: '{{ light_transition / 1000 }}'
-            default:
-              - service: light.turn_on
-                entity_id: !input light
-                data:
-                  transition: '{{ light_transition / 1000 }}'
-      - conditions: '{{ action == turn_off }}'
+        - service: light.turn_on
+          entity_id: !input light
+          data:
+            brightness: !input on_brightness
+            transition: '{{ light_transition / 1000 }}'
+      default:
+      - service: light.turn_on
+        entity_id: !input light
+        data:
+          transition: '{{ light_transition / 1000 }}'
+  - conditions: '{{ action == turn_off }}'
+    sequence:
+    - service: light.turn_off
+      entity_id: !input light
+      data:
+        transition: '{{ light_transition / 1000 }}'
+  - conditions: '{{ action == brightness_up }}'
+    sequence:
+    - choose:
+      - conditions: '{{ states(light) == "off" and not smooth_power_on}}'
         sequence:
-          - service: light.turn_off
+        - service: light.turn_on
+          data:
+            transition: '{{ light_transition / 1000 }}'
             entity_id: !input light
-            data:
-              transition: '{{ light_transition / 1000 }}'
-      - conditions: '{{ action == brightness_up }}'
+      - conditions: '{{ states(light) == "off" and smooth_power_on}}'
         sequence:
-          - choose:
-              # if light is off and smooth power on is disabled, turn it on at the previously saved brightness
-              - conditions: '{{ states(light) == "off" and not smooth_power_on}}'
-                sequence:
-                  - service: light.turn_on
-                    data:
-                      transition: '{{ light_transition / 1000 }}'
-                      entity_id: !input light
-              # if light is off and smooth power on is enabled, turn it on at minimum brightness
-              - conditions: '{{ states(light) == "off" and smooth_power_on}}'
-                sequence:
-                  - service: light.turn_on
-                    data:
-                      brightness: '{{ min_brightness }}'
-                      transition: '{{ light_transition / 1000 }}'
-                      entity_id: !input light
-            # else the light is on, hence increase its brightness
-            default:
-              - service: light.turn_on
-                data:
-                  brightness: '{{ [ [state_attr(light,"brightness")+step_short, min_brightness] | max, max_brightness] | min }}'
-                  transition: 0.25
-                  entity_id: !input light
-      - conditions: '{{ action == brightness_down and states(light) == "on" }}'
+        - service: light.turn_on
+          data:
+            brightness: '{{ min_brightness }}'
+            transition: '{{ light_transition / 1000 }}'
+            entity_id: !input light
+      default:
+      - service: light.turn_on
+        data:
+          brightness: '{{ [ [state_attr(light,"brightness")+step_short, min_brightness]
+            | max, max_brightness] | min }}'
+          transition: 0.25
+          entity_id: !input light
+  - conditions: '{{ action == brightness_down and states(light) == "on" }}'
+    sequence:
+    - choose:
+      - conditions: '{{ smooth_power_off and state_attr(light,"brightness") == min_brightness
+          }}'
         sequence:
-          - choose:
-              - conditions: '{{ smooth_power_off and state_attr(light,"brightness") == min_brightness }}'
-                sequence:
-                  - service: light.turn_off
-                    data:
-                      transition: '{{ light_transition / 1000 }}'
-                      entity_id: !input light
-            default:
-              - service: light.turn_on
-                data:
-                  brightness: '{{ [ [state_attr(light,"brightness")-step_short, min_brightness] | max, max_brightness] | min }}'
-                  transition: 0.25
-                  entity_id: !input light
-      - conditions: '{{ action == brightness_up_repeat }}'
+        - service: light.turn_off
+          data:
+            transition: '{{ light_transition / 1000 }}'
+            entity_id: !input light
+      default:
+      - service: light.turn_on
+        data:
+          brightness: '{{ [ [state_attr(light,"brightness")-step_short, min_brightness]
+            | max, max_brightness] | min }}'
+          transition: 0.25
+          entity_id: !input light
+  - conditions: '{{ action == brightness_up_repeat }}'
+    sequence:
+    - choose:
+      - conditions: '{{ states(light) == "off" and not smooth_power_on}}'
         sequence:
-          # first step for the smooth power on feature: subsequent steps can skip this check since light will be already on
-          - choose:
-              # if light is off and smooth power on is disabled, turn it on at the previously saved brightness
-              - conditions: '{{ states(light) == "off" and not smooth_power_on}}'
+        - service: light.turn_on
+          data:
+            transition: '{{ light_transition / 1000 }}'
+            entity_id: !input light
+        - delay:
+            milliseconds: !input light_transition
+      - conditions: '{{ states(light) == "off" and smooth_power_on}}'
+        sequence:
+        - service: light.turn_on
+          data:
+            brightness: '{{ min_brightness }}'
+            transition: '{{ light_transition / 1000 }}'
+            entity_id: !input light
+        - delay:
+            milliseconds: !input light_transition
+    - repeat:
+        while: '{{ true }}'
+        sequence:
+        - service: light.turn_on
+          data:
+            brightness: '{{ [ [state_attr(light,"brightness")+step_long, min_brightness]
+              | max, max_brightness] | min }}'
+            transition: 0.25
+            entity_id: !input light
+        - delay:
+            milliseconds: 250
+  - conditions: '{{ action == brightness_down_repeat and states(light) == "on"  }}'
+    sequence:
+    - choose:
+      - conditions: '{{ smooth_power_off }}'
+        sequence:
+        - repeat:
+            while: '{{ states(light) != "off" }}'
+            sequence:
+            - choose:
+              - conditions: '{{ state_attr(light,"brightness") == min_brightness }}'
                 sequence:
-                  - service: light.turn_on
-                    data:
-                      transition: '{{ light_transition / 1000 }}'
-                      entity_id: !input light
-                  - delay:
-                      milliseconds: !input light_transition
-              # if light is off and smooth power on is enabled, turn it on at minimum brightness
-              - conditions: '{{ states(light) == "off" and smooth_power_on}}'
-                sequence:
-                  - service: light.turn_on
-                    data:
-                      brightness: '{{ min_brightness }}'
-                      transition: '{{ light_transition / 1000 }}'
-                      entity_id: !input light
-                  - delay:
-                      milliseconds: !input light_transition
-          # else move on to the loop for increasing the light brightness
-          - repeat:
-              while: '{{ true }}'
-              sequence:
-                - service: light.turn_on
+                - service: light.turn_off
                   data:
-                    brightness: '{{ [ [state_attr(light,"brightness")+step_long, min_brightness] | max, max_brightness] | min }}'
-                    transition: 0.25
+                    transition: '{{ light_transition / 1000 }}'
                     entity_id: !input light
                 - delay:
-                    milliseconds: 250
-      - conditions: '{{ action == brightness_down_repeat and states(light) == "on"  }}'
+                    milliseconds: !input light_transition
+              default:
+              - service: light.turn_on
+                data:
+                  brightness: '{{ [ [state_attr(light,"brightness")-step_long, min_brightness]
+                    | max, max_brightness] | min }}'
+                  transition: 0.25
+                  entity_id: !input light
+              - delay:
+                  milliseconds: 250
+      default:
+      - repeat:
+          while: '{{ states(light) != "off" }}'
+          sequence:
+          - service: light.turn_on
+            data:
+              brightness: '{{ [ [state_attr(light,"brightness")-step_long, min_brightness]
+                | max, max_brightness] | min }}'
+              transition: 0.25
+              entity_id: !input light
+          - delay:
+              milliseconds: 250
+  - conditions: '{{ action == color_up and light_color_mode_id != "none" }}'
+    sequence:
+      choose:
+      - conditions: '{{ light_color_mode_id == "color_temp" and enable_clamp_color_temp
+          }}'
         sequence:
-          - choose:
-              # using a separate sequence for the smooth power off feature to not perform unnecessary checks at every iteration when the feature is disabled
-              - conditions: '{{ smooth_power_off }}'
-                sequence:
-                  - repeat:
-                      # continue lowering brightness until the light turns off
-                      while: '{{ states(light) != "off" }}'
-                      sequence:
-                        - choose:
-                            # if the light is at minimum brightness, turn it off
-                            - conditions: '{{ state_attr(light,"brightness") == min_brightness }}'
-                              sequence:
-                                - service: light.turn_off
-                                  data:
-                                    transition: '{{ light_transition / 1000 }}'
-                                    entity_id: !input light
-                                - delay:
-                                    milliseconds: !input light_transition
-                          # else lower the light's brightness
-                          default:
-                            - service: light.turn_on
-                              data:
-                                brightness: '{{ [ [state_attr(light,"brightness")-step_long, min_brightness] | max, max_brightness] | min }}'
-                                transition: 0.25
-                                entity_id: !input light
-                            - delay:
-                                milliseconds: 250
-            default:
-              - repeat:
-                  # continue lowering brightness until the light turns off
-                  while: '{{ states(light) != "off" }}'
-                  sequence:
-                    # lower the light's brightness. since smooth power off is disabled, never let the brightness move below the user-provided minimum
-                    - service: light.turn_on
-                      data:
-                        brightness: '{{ [ [state_attr(light,"brightness")-step_long, min_brightness] | max, max_brightness] | min }}'
-                        transition: 0.25
-                        entity_id: !input light
-                    - delay:
-                        milliseconds: 250
-      - conditions: '{{ action == color_up and light_color_mode_id != "none" }}'
+        - service: light.turn_on
+          data:
+            color_temp: '{{ [ [state_attr(light,"color_temp")|int + 50, min_color_temp]
+              | max, max_color_temp] | min }}'
+            transition: 0.25
+          entity_id: !input light
+      - conditions: '{{ light_color_mode_id == "color_temp" }}'
         sequence:
-          choose:
-            - conditions: '{{ light_color_mode_id == "color_temp" and enable_clamp_color_temp }}'
-              sequence:
-                - service: light.turn_on
-                  data:
-                    color_temp: '{{ [ [state_attr(light,"color_temp")|int + 50, min_color_temp] | max, max_color_temp] | min }}'
-                    transition: 0.25
-                  entity_id: !input light
-            - conditions: '{{ light_color_mode_id == "color_temp" }}'
-              sequence:
-                - service: light.turn_on
-                  data:
-                    color_temp: '{{ state_attr(light,"color_temp")|int + 50 }}'
-                    transition: 0.25
-                  entity_id: !input light
-            - conditions: '{{ light_color_mode_id == "hs_color" }}'
-              sequence:
-                - service: light.turn_on
-                  data:
-                    hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) + 15) % 360, 100] }}'
-                    transition: 0.25
-                  entity_id: !input light
-      - conditions: '{{ action == color_down and light_color_mode_id != "none" }}'
+        - service: light.turn_on
+          data:
+            color_temp: '{{ state_attr(light,"color_temp")|int + 50 }}'
+            transition: 0.25
+          entity_id: !input light
+      - conditions: '{{ light_color_mode_id == "hs_color" }}'
         sequence:
-          choose:
-            - conditions: '{{ light_color_mode_id == "color_temp" and enable_clamp_color_temp }}'
-              sequence:
-                - service: light.turn_on
-                  data:
-                    color_temp: '{{ [ [state_attr(light,"color_temp")|int - 50, min_color_temp] | max, max_color_temp] | min }}'
-                    transition: 0.25
-                  entity_id: !input light
-            - conditions: '{{ light_color_mode_id == "color_temp" }}'
-              sequence:
-                - service: light.turn_on
-                  data:
-                    color_temp: '{{ [state_attr(light,"color_temp")|int - 50, 1]|max }}'
-                    transition: 0.25
-                  entity_id: !input light
-            - conditions: '{{ light_color_mode_id == "hs_color" }}'
-              sequence:
-                - service: light.turn_on
-                  data:
-                    hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }}'
-                    transition: 0.25
-                  entity_id: !input light
-      - conditions: '{{ action == color_up_repeat and light_color_mode_id != "none" }}'
+        - service: light.turn_on
+          data:
+            hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) + 15) % 360, 100]
+              }}'
+            transition: 0.25
+          entity_id: !input light
+  - conditions: '{{ action == color_down and light_color_mode_id != "none" }}'
+    sequence:
+      choose:
+      - conditions: '{{ light_color_mode_id == "color_temp" and enable_clamp_color_temp
+          }}'
         sequence:
-          choose:
-            - conditions: '{{ light_color_mode_id == "color_temp" and enable_clamp_color_temp }}'
-              sequence:
-                - repeat:
-                    while: '{{ true }}'
-                    sequence:
-                      - service: light.turn_on
-                        data:
-                          color_temp: '{{ [ [state_attr(light,"color_temp")|int + 50, min_color_temp] | max, max_color_temp] | min }}'
-                          transition: 0.25
-                        entity_id: !input light
-                      - delay:
-                          milliseconds: 250
-            - conditions: '{{ light_color_mode_id == "color_temp" }}'
-              sequence:
-                - repeat:
-                    while: '{{ true }}'
-                    sequence:
-                      - service: light.turn_on
-                        data:
-                          color_temp: '{{ state_attr(light,"color_temp")|int + 50 }}'
-                          transition: 0.25
-                        entity_id: !input light
-                      - delay:
-                          milliseconds: 250
-            - conditions: '{{ light_color_mode_id == "hs_color" }}'
-              sequence:
-                - repeat:
-                    while: '{{ true }}'
-                    sequence:
-                      - service: light.turn_on
-                        data:
-                          hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) + 15) % 360, 100] }}'
-                          transition: 0.25
-                        entity_id: !input light
-                      - delay:
-                          milliseconds: 250
-      - conditions: '{{ action == color_down_repeat and light_color_mode_id != "none" }}'
+        - service: light.turn_on
+          data:
+            color_temp: '{{ [ [state_attr(light,"color_temp")|int - 50, min_color_temp]
+              | max, max_color_temp] | min }}'
+            transition: 0.25
+          entity_id: !input light
+      - conditions: '{{ light_color_mode_id == "color_temp" }}'
         sequence:
-          choose:
-            - conditions: '{{ light_color_mode_id == "color_temp" and enable_clamp_color_temp }}'
-              sequence:
-                - repeat:
-                    while: '{{ true }}'
-                    sequence:
-                      - service: light.turn_on
-                        data:
-                          color_temp: '{{ [ [state_attr(light,"color_temp")|int - 50, min_color_temp] | max, max_color_temp] | min }}'
-                          transition: 0.25
-                        entity_id: !input light
-                      - delay:
-                          milliseconds: 250
-            - conditions: '{{ light_color_mode_id == "color_temp"}}'
-              sequence:
-                - repeat:
-                    while: '{{ true }}'
-                    sequence:
-                      - service: light.turn_on
-                        data:
-                          color_temp: '{{ [state_attr(light,"color_temp")|int - 50, 1]|max }}'
-                          transition: 0.25
-                        entity_id: !input light
-                      - delay:
-                          milliseconds: 250
-            - conditions: '{{ light_color_mode_id == "hs_color" }}'
-              sequence:
-                - repeat:
-                    while: '{{ true }}'
-                    sequence:
-                      - service: light.turn_on
-                        data:
-                          hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }}'
-                          transition: 0.25
-                        entity_id: !input light
-                      - delay:
-                          milliseconds: 250
+        - service: light.turn_on
+          data:
+            color_temp: '{{ [state_attr(light,"color_temp")|int - 50, 1]|max }}'
+            transition: 0.25
+          entity_id: !input light
+      - conditions: '{{ light_color_mode_id == "hs_color" }}'
+        sequence:
+        - service: light.turn_on
+          data:
+            hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100]
+              }}'
+            transition: 0.25
+          entity_id: !input light
+  - conditions: '{{ action == color_up_repeat and light_color_mode_id != "none" }}'
+    sequence:
+      choose:
+      - conditions: '{{ light_color_mode_id == "color_temp" and enable_clamp_color_temp
+          }}'
+        sequence:
+        - repeat:
+            while: '{{ true }}'
+            sequence:
+            - service: light.turn_on
+              data:
+                color_temp: '{{ [ [state_attr(light,"color_temp")|int + 50, min_color_temp]
+                  | max, max_color_temp] | min }}'
+                transition: 0.25
+              entity_id: !input light
+            - delay:
+                milliseconds: 250
+      - conditions: '{{ light_color_mode_id == "color_temp" }}'
+        sequence:
+        - repeat:
+            while: '{{ true }}'
+            sequence:
+            - service: light.turn_on
+              data:
+                color_temp: '{{ state_attr(light,"color_temp")|int + 50 }}'
+                transition: 0.25
+              entity_id: !input light
+            - delay:
+                milliseconds: 250
+      - conditions: '{{ light_color_mode_id == "hs_color" }}'
+        sequence:
+        - repeat:
+            while: '{{ true }}'
+            sequence:
+            - service: light.turn_on
+              data:
+                hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) + 15) % 360,
+                  100] }}'
+                transition: 0.25
+              entity_id: !input light
+            - delay:
+                milliseconds: 250
+  - conditions: '{{ action == color_down_repeat and light_color_mode_id != "none"
+      }}'
+    sequence:
+      choose:
+      - conditions: '{{ light_color_mode_id == "color_temp" and enable_clamp_color_temp
+          }}'
+        sequence:
+        - repeat:
+            while: '{{ true }}'
+            sequence:
+            - service: light.turn_on
+              data:
+                color_temp: '{{ [ [state_attr(light,"color_temp")|int - 50, min_color_temp]
+                  | max, max_color_temp] | min }}'
+                transition: 0.25
+              entity_id: !input light
+            - delay:
+                milliseconds: 250
+      - conditions: '{{ light_color_mode_id == "color_temp"}}'
+        sequence:
+        - repeat:
+            while: '{{ true }}'
+            sequence:
+            - service: light.turn_on
+              data:
+                color_temp: '{{ [state_attr(light,"color_temp")|int - 50, 1]|max }}'
+                transition: 0.25
+              entity_id: !input light
+            - delay:
+                milliseconds: 250
+      - conditions: '{{ light_color_mode_id == "hs_color" }}'
+        sequence:
+        - repeat:
+            while: '{{ true }}'
+            sequence:
+            - service: light.turn_on
+              data:
+                hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360,
+                  100] }}'
+                transition: 0.25
+              entity_id: !input light
+            - delay:
+                milliseconds: 250

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -41,6 +41,7 @@ blueprint:
           options:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+            - IKEA E2201 RODRET Dimmer
             - IKEA E1744 SYMFONISK Rotary Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1812 TRÅDFRI Shortcut button
@@ -103,6 +104,12 @@ variables:
       play_pause: button_center_short
       stop: button_center_long
     IKEA E1743 TRÅDFRI On/Off Switch & Dimmer:
+      volume_up: button_up_short
+      volume_up_repeat: button_up_long
+      next_track: button_up_double
+      volume_down: button_down_long
+      play_pause: button_down_double
+    IKEA E2201 RODRET Dimmer:
       volume_up: button_up_short
       volume_up_repeat: button_up_long
       next_track: button_up_double


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Breaking change
This may  break existing automations based on the older version for ikea Tradfri e1743 if being used.

A redownload/update/resetup of the ikea_1743.yaml will probably be needed.

To use the new Ikea Rodret e2201 controller a redownload/update/resetup of the hooks will also be needed.

## Proposed change\*

Added Support for IKEA RODRET wireless dimmer/power switch (E2201)
as a controller and added it to the relevant hooks. The controller should now work with the upcomming release of zigbee2mqtt 2.0.0 as triggeres were refactored to use mqtt rather than the depecrated sensor.\<DEVICE\>_action.

Additionaly Updated IKEA E1743 TRÅDFRI On/Off Switch & Dimmer controller also to use mqtt triggers.

## Checklist\*

- [ Y] I followed sections of the [Contribution Guidelines](https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [ Y] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ Y] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
