### PR TITLE
Updated IKEA E1743 TRÅDFRI On/Off Switch & Dimmer controller to use mqtt triggers. The controller should now work with the upcomming release of zigbee2mqtt 2.0.0 as triggers were refactored to use mqtt rather than the depecrated sensor.<DEVICE>_action.

### DIFF
--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -38,11 +38,18 @@ blueprint:
         device:
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+#CHANGED - YAR      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
       default: ''
       selector:
-        entity:
-          domain: sensor
+#CHANGED - YAR        entity:
+#CHANGED - YAR          domain: sensor
+        device:
+          filter:
+          - integration: mqtt
+            manufacturer: IKEA
+            model: TRADFRI on/off switch (E1743)
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -233,10 +240,35 @@ mode: restart
 max_exceeded: silent
 trigger:
   # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
+#CHANGED - YAR  - platform: event
+#CHANGED - YAR    event_type: state_changed
+#CHANGED - YAR    event_data:
+#CHANGED - YAR      entity_id: !input controller_entity
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_entity
+    type: action
+    subtype: 'on'
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_entity
+    type: action
+    subtype: 'off'
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_entity
+    type: action
+    subtype: brightness_move_up
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_entity
+    type: action
+    subtype: brightness_move_down
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_entity
+    type: action
+    subtype: brightness_stop
   # trigger for other integrations
   - platform: event
     event_type:
@@ -251,7 +283,8 @@ condition:
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+#CHANGED - YAR        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -261,7 +294,8 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#CHANGED - YAR      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt" or trigger.payload != last_controller_event }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -273,7 +307,8 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+#CHANGED - YAR        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -3,14 +3,13 @@ blueprint:
   homeassistant:
     min_version: "2023.6.0"
   name: Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+  #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   description: |
     # Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1743 TRÅDFRI On/Off Switch & Dimmer. Allows to optionally loop an action on a button long press.
-#YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT V2.0.0 with legacy=false.
-#YAR - ADD END
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -21,6 +20,7 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2023.10.05
+  #YAR - ADD END
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
   domain: automation
   input:
@@ -33,9 +33,9 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+            #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
             - Zigbee2MQTT_V2
-#YAR - ADD END
+            #YAR - ADD END
     controller_device:
       name: (deCONZ, ZHA) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
@@ -49,7 +49,7 @@ blueprint:
       selector:
         entity:
           domain: sensor
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     controller_mqtt:
       name: (Zigbee2MQTT v2.0.0) Controller MQTT Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -61,7 +61,7 @@ blueprint:
             manufacturer: IKEA
             model: TRADFRI on/off switch (E1743)
           multiple: false
-#YAR - ADD END
+    #YAR - ADD END
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -234,7 +234,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     zigbee2mqtt_v2:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -242,7 +242,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
-#YAR - ADD END
+    #YAR - ADD END
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_up_short: '{{ actions_mapping[integration_id]["button_up_short"] }}'
@@ -252,18 +252,18 @@ variables:
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # integrations which need to store the previous press event to determine which button was released
-#YAR - CHANGED  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - CHANGED  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
-#YAR - ADD END
+  #YAR - ADD END
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   controller_mqtt: !input controller_mqtt
-#YAR - ADD END
-#YAR - CHANGED  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD END
+  #YAR - CHANGED  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   controller_id: '{% if integration_id=="zigbee2mqtt" %}
                   {{controller_entity}}
                   {% elif integration_id == "zigbee2mqtt_v2" %}
@@ -271,7 +271,7 @@ variables:
                   {% else %}
                   {{controller_device}}
                   {% endif %}'
-#YAR - ADD END
+  #YAR - ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -280,7 +280,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   # triggers for zigbee2mqtt_v2
   - platform: device
     domain: mqtt
@@ -307,7 +307,7 @@ trigger:
     device_id: !input controller_mqtt
     type: action
     subtype: brightness_stop
-#YAR - ADD END
+  #YAR - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -319,14 +319,13 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
         {%- elif integration_id == "zigbee2mqtt_v2" -%}
         {{ trigger.payload }}
-#YAR - ADD END
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -334,12 +333,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
+      #YAR - ADD END
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
       - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
-#YAR - ADD END
+      #YAR - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -349,18 +349,18 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
         {%- elif integration_id == "zigbee2mqtt_v2" -%}
         {{ trigger.payload }}
-#YAR - ADD END
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
+      #YAR - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -2,11 +2,11 @@
 blueprint:
   homeassistant:
     min_version: "2023.6.0"
-  name: Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+  name: Controller - IKEA E2201 RODRET Dimmer
   description: |
-    # Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+    # Controller - IKEA E2201 RODRET Dimmer
 
-    Controller automation for executing any kind of action triggered by the provided IKEA E1743 TRÅDFRI On/Off Switch & Dimmer. Allows to optionally loop an action on a button long press.
+    Controller automation for executing any kind of action triggered by the provided IKEA E2201 RODRET Dimmer. Allows to optionally loop an action on a button long press.
 #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
 #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT V2.0.0 with legacy=false.
@@ -59,7 +59,7 @@ blueprint:
           filter:
           - integration: mqtt
             manufacturer: IKEA
-            model: TRADFRI on/off switch (E1743)
+            model: RODRET wireless dimmer/power switch (E2201)
           multiple: false
 #YAR - ADD END
     helper_last_controller_event:

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -3,14 +3,13 @@ blueprint:
   homeassistant:
     min_version: "2023.6.0"
   name: Controller - IKEA E2201 RODRET Dimmer
+  #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   description: |
     # Controller - IKEA E2201 RODRET Dimmer
 
     Controller automation for executing any kind of action triggered by the provided IKEA E2201 RODRET Dimmer. Allows to optionally loop an action on a button long press.
-#YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT V2.0.0 with legacy=false.
-#YAR - ADD END
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -21,6 +20,7 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2023.10.05
+  #YAR - ADD END
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
   domain: automation
   input:
@@ -33,9 +33,9 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+            #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
             - Zigbee2MQTT_V2
-#YAR - ADD END
+            #YAR - ADD END
     controller_device:
       name: (deCONZ, ZHA) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
@@ -49,7 +49,7 @@ blueprint:
       selector:
         entity:
           domain: sensor
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     controller_mqtt:
       name: (Zigbee2MQTT v2.0.0) Controller MQTT Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -61,7 +61,7 @@ blueprint:
             manufacturer: IKEA
             model: RODRET wireless dimmer/power switch (E2201)
           multiple: false
-#YAR - ADD END
+    #YAR - ADD END
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -234,7 +234,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     zigbee2mqtt_v2:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -242,7 +242,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
-#YAR - ADD END
+    #YAR - ADD END
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_up_short: '{{ actions_mapping[integration_id]["button_up_short"] }}'
@@ -252,18 +252,18 @@ variables:
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # integrations which need to store the previous press event to determine which button was released
-#YAR - CHANGED  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - CHANGED  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
-#YAR - ADD END
+  #YAR - ADD END
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   controller_mqtt: !input controller_mqtt
-#YAR - ADD END
-#YAR - CHANGED  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD END
+  #YAR - CHANGED  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   controller_id: '{% if integration_id=="zigbee2mqtt" %}
                   {{controller_entity}}
                   {% elif integration_id == "zigbee2mqtt_v2" %}
@@ -271,7 +271,7 @@ variables:
                   {% else %}
                   {{controller_device}}
                   {% endif %}'
-#YAR - ADD END
+  #YAR - ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -280,7 +280,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   # triggers for zigbee2mqtt_v2
   - platform: device
     domain: mqtt
@@ -307,7 +307,7 @@ trigger:
     device_id: !input controller_mqtt
     type: action
     subtype: brightness_stop
-#YAR - ADD END
+  #YAR - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -319,14 +319,13 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
         {%- elif integration_id == "zigbee2mqtt_v2" -%}
         {{ trigger.payload }}
-#YAR - ADD END
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -334,12 +333,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
+      #YAR - ADD END
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
       - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
-#YAR - ADD END
+      #YAR - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -349,18 +349,18 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
         {%- elif integration_id == "zigbee2mqtt_v2" -%}
         {{ trigger.payload }}
-#YAR - ADD END
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
+      #YAR - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/hooks/cover/cover.yaml
+++ b/blueprints/hooks/cover/cover.yaml
@@ -33,6 +33,17 @@ blueprint:
       selector:
         entity:
           domain: sensor
+#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    controller_mqtt:
+      name: (Required) Controller MQTT Device
+      description: The controller device which will control the Cover. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as a Device. This value should match the one specified in the corresponding Controller automation.
+      default: ''
+      selector:
+        device:
+          filter:
+          - integration: mqtt
+          multiple: false
+#YAR - ADD END
     controller_model:
       name: (Required) Controller model
       description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
@@ -41,6 +52,9 @@ blueprint:
           options:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+#YAR - ADD - IKEA RODRET
+            - IKEA E2201 RODRET Dimmer
+#YAR - ADD - END
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1812 TRÅDFRI Shortcut button
             - SONOFF SNZB-01 Wireless Switch
@@ -75,6 +89,14 @@ variables:
       close_cover: button_down_short
       close_cover_tilt: button_down_long
       stop_cover_all: button_down_double
+#YAR - ADD - IKEA RODRET
+    IKEA E2201 RODRET Dimmer:
+      open_cover: button_up_short
+      open_cover_tilt: button_up_long
+      close_cover: button_down_short
+      close_cover_tilt: button_down_long
+      stop_cover_all: button_down_double
+#YAR - ADD END
     IKEA E1766 TRÅDFRI Open/Close Remote:
       open_cover: button_up_short
       close_cover: button_down_short
@@ -145,6 +167,12 @@ trigger:
     event_type: ahb_controller_event
     event_data:
       controller: !input controller_entity
+#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  - platform: event
+    event_type: ahb_controller_event
+    event_data:
+      controller: !input controller_mqtt
+#YAR - ADD END
 condition: []
 action:
   - variables:

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -33,6 +33,17 @@ blueprint:
       selector:
         entity:
           domain: sensor
+#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    controller_mqtt:
+      name: (Required) Controller MQTT Device
+      description: The controller device which will control the Light. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as a Device. This value should match the one specified in the corresponding Controller automation.
+      default: ''
+      selector:
+        device:
+          filter:
+          - integration: mqtt
+          multiple: false
+#YAR - ADD END
     controller_model:
       name: (Required) Controller model
       description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
@@ -42,6 +53,10 @@ blueprint:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer (#2)
+#YAR - ADD - IKEA RODRET
+            - IKEA E2201 RODRET Dimmer
+            - IKEA E2201 RODRET Dimmer (#2)
+#YAR - ADD - END
             - IKEA E1744 SYMFONISK Rotary Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote (#2)
@@ -221,6 +236,22 @@ variables:
       brightness_down: button_down_short
       brightness_down_repeat: button_down_long
       turn_off: button_down_double
+#YAR - ADD - IKEA RODRET
+    IKEA E2201 RODRET Dimmer:
+      turn_on: button_up_short
+      brightness_up_repeat: button_up_long
+      color_up: button_up_double
+      turn_off: button_down_short
+      brightness_down_repeat: button_down_long
+      color_down: button_down_double
+    IKEA E2201 RODRET Dimmer (#2):
+      brightness_up: button_up_short
+      brightness_up_repeat: button_up_long
+      turn_on: button_up_double
+      brightness_down: button_down_short
+      brightness_down_repeat: button_down_long
+      turn_off: button_down_double
+#YAR - ADD END
     IKEA E1744 SYMFONISK Rotary Remote:
       brightness_down_repeat: rotate_left
       brightness_up_repeat: rotate_right
@@ -397,6 +428,12 @@ trigger:
     event_type: ahb_controller_event
     event_data:
       controller: !input controller_entity
+#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  - platform: event
+    event_type: ahb_controller_event
+    event_data:
+      controller: !input controller_mqtt
+#YAR - ADD END
 condition: []
 action:
   - variables:

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -33,6 +33,17 @@ blueprint:
       selector:
         entity:
           domain: sensor
+#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    controller_mqtt:
+      name: (Required) Controller MQTT Device
+      description: The controller device which will control the Media Player. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as a Device. This value should match the one specified in the corresponding Controller automation.
+      default: ''
+      selector:
+        device:
+          filter:
+          - integration: mqtt
+          multiple: false
+#YAR - ADD END
     controller_model:
       name: (Required) Controller model
       description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
@@ -41,6 +52,9 @@ blueprint:
           options:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+#YAR - ADD - IKEA RODRET
+            - IKEA E2201 RODRET Dimmer
+#YAR - ADD - END
             - IKEA E1744 SYMFONISK Rotary Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1812 TRÅDFRI Shortcut button
@@ -108,6 +122,14 @@ variables:
       next_track: button_up_double
       volume_down: button_down_long
       play_pause: button_down_double
+#YAR - ADD - IKEA RODRET
+    IKEA E2201 RODRET Dimmer:
+      volume_up: button_up_short
+      volume_up_repeat: button_up_long
+      next_track: button_up_double
+      volume_down: button_down_long
+      play_pause: button_down_double
+#YAR - ADD END
     IKEA E1744 SYMFONISK Rotary Remote:
       volume_down_repeat: rotate_left
       volume_up_repeat: rotate_right
@@ -234,6 +256,12 @@ trigger:
     event_type: ahb_controller_event
     event_data:
       controller: !input controller_entity
+#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  - platform: event
+    event_type: ahb_controller_event
+    event_data:
+      controller: !input controller_mqtt
+#YAR - ADD END
 condition: []
 action:
   - variables:


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Breaking change

This may break existing automations based on the older version for ikea Tradfri e1743 if being used.
A redownload/update/resetup of the ikea_1743.yaml will probably be needed.

## Proposed change\*

Updated IKEA E1743 TRÅDFRI On/Off Switch & Dimmer controller to use mqtt triggers.
The controller should now work with the upcomming release of zigbee2mqtt 2.0.0 as triggers were refactored to use mqtt rather than the depecrated sensor.<DEVICE>_action.

## Checklist\*

- [Y] I followed sections of the [Contribution Guidelines](https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [Y] I properly tested proposed changes on my system and confirm that they are working as expected.
- [Y] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
