### PR TITLE
Update to support mqtt based triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: npm ci
       - id: prettier
         name: Prettier
-        uses: creyD/prettier_action@v4.2
+        uses: creyD/prettier_action@v4.3
         with:
           dry: true
           prettier_options: --write .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Create .nojekyll file
         run: touch website/build/.nojekyll
       - name: Deploy to GitHub Pages
-        uses: s0/git-publish-subdir-action@v2.5.1
+        uses: s0/git-publish-subdir-action@v2.6.0
         env:
           REPO: self
           BRANCH: gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: '16'
       - name: Cache node modules
-        uses: actions/cache@v3.0.6
+        uses: actions/cache@v3.2.6
         env:
           cache-name: cache-node-modules
         with:
@@ -64,7 +64,7 @@ jobs:
         with:
           node-version: '16'
       - name: Cache node modules
-        uses: actions/cache@v3.0.6
+        uses: actions/cache@v3.2.6
         env:
           cache-name: cache-node-modules
         with:
@@ -103,7 +103,7 @@ jobs:
         with:
           node-version: '16'
       - name: Cache node modules
-        uses: actions/cache@v3.0.6
+        uses: actions/cache@v3.2.6
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - if: always()
         id: eslint
         name: ESLint
-        uses: reviewdog/action-eslint@v1.17
+        uses: reviewdog/action-eslint@v1.18
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -94,7 +94,7 @@ jobs:
         run: cd website && npm ci
       - id: prettier
         name: Prettier Check
-        uses: creyD/prettier_action@v4.2
+        uses: creyD/prettier_action@v4.3
         with:
           dry: true
           prettier_options: --write .

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -42,7 +42,7 @@ jobs:
         continue-on-error: true
       - id: eslint
         name: ESLint
-        uses: reviewdog/action-eslint@v1.17
+        uses: reviewdog/action-eslint@v1.18
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '16'
       - name: Cache node modules
-        uses: actions/cache@v3.0.6
+        uses: actions/cache@v3.2.6
         env:
           cache-name: cache-node-modules
         with:
@@ -77,7 +77,7 @@ jobs:
         with:
           node-version: '16'
       - name: Cache node modules
-        uses: actions/cache@v3.0.6
+        uses: actions/cache@v3.2.6
         env:
           cache-name: cache-node-modules
         with:
@@ -121,7 +121,7 @@ jobs:
         with:
           node-version: '16'
       - name: Cache node modules
-        uses: actions/cache@v3.0.6
+        uses: actions/cache@v3.2.6
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 90 days stale policy for issues & PRs
-        uses: actions/stale@v5
+        uses: actions/stale@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 90

--- a/.github/workflows/thread_locker.yml
+++ b/.github/workflows/thread_locker.yml
@@ -19,7 +19,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v3
+      - uses: dessant/lock-threads@v4
         with:
           # 30 days of inactivity both for closed issues and PRs
           issue-inactive-days: 30

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -1,12 +1,14 @@
 # Blueprint metadata
 blueprint:
   domain: automation
+  homeassistant:
+    min_version: 2023.5.0
   name: Controller - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
   description: |
     # Controller - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -16,9 +18,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025-01-01
-
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+    ℹ️ Version 2025.01.03
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
   input:
     integration:
       name: (Required) Integration
@@ -29,17 +31,25 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+#**YAR** - ADD END
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
+#**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
+#**YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
           filter:
           - integration: mqtt
             manufacturer: IKEA
+            model: TRADFRI remote control
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: IKEA
             model: TRADFRI remote control (E1524/E1810)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI remote control
@@ -47,6 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI remote control
           multiple: false
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -354,30 +365,16 @@ variables:
       button_right_short: [press_256_13_0]
       button_right_long: [hold_3328_0]
       button_right_release: [release]
-      button_up_short: [step_with_on_off_StepMode.Up_43_5]
-      button_up_long: [move_with_on_off_MoveMode.Up_83]
-      button_up_release: [stop_with_on_off]
-      button_down_short: [step_StepMode.Down_43_5_0_0]
-      button_down_long: [move_MoveMode.Down_83]
+      button_up_short: [step_with_on_off_0_43_5]
+      button_up_long: [move_with_on_off_0_83, move_with_on_off_0_84]
+      button_up_release: [stop]
+      button_down_short: [step_1_43_5]
+      button_down_long: [move_1_83, move_1_84]
       button_down_release: [stop]
       button_center_short: [toggle]
       button_center_long: [press_2_0_0]
+#**YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
     zigbee2mqtt:
-      button_left_short: [arrow_left_click]
-      button_left_long: [arrow_left_hold]
-      button_left_release: [arrow_left_release]
-      button_right_short: [arrow_right_click]
-      button_right_long: [arrow_right_hold]
-      button_right_release: [arrow_right_release]
-      button_up_short: [brightness_up_click]
-      button_up_long: [brightness_up_hold]
-      button_up_release: [brightness_up_release]
-      button_down_short: [brightness_down_click]
-      button_down_long: [brightness_down_hold]
-      button_down_release: [brightness_down_release]
-      button_center_short: [toggle]
-      button_center_long: [toggle_hold]
-    zigbee2mqtt_v2:
       button_left_short: [arrow_left_click]
       button_left_long: [arrow_left_hold]
       button_left_release: [arrow_left_release]
@@ -409,20 +406,26 @@ variables:
   button_center_short: '{{ actions_mapping[integration_id]["button_center_short"] }}'
   button_center_long: '{{ actions_mapping[integration_id]["button_center_long"] }}'
   # integrations which need to store the previous press event to determine which button was released
-  integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
+  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -493,6 +496,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: toggle_hold
+#**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -504,12 +508,13 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -517,10 +522,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+#**YAR** - ADD END
+       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -530,19 +538,20 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
-
   # update helper
   - service: input_text.set_value
     data:

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -32,15 +32,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-#**YAR** - ADD END
+ #**YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-#**YAR** - ADD - Selector for devices to choose from
+ #**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-#**YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -49,7 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI remote control (E1524/E1810)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI remote control
@@ -57,7 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI remote control
           multiple: false
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -373,7 +373,7 @@ variables:
       button_down_release: [stop]
       button_center_short: [toggle]
       button_center_long: [press_2_0_0]
-#**YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
     zigbee2mqtt:
       button_left_short: [arrow_left_click]
       button_left_long: [arrow_left_hold]
@@ -410,12 +410,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -424,7 +424,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -496,7 +496,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: toggle_hold
-#**YAR** - ADD END
+ #**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -508,7 +508,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -522,13 +522,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-#**YAR** - ADD END
+ #**YAR** - ADD END
        # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
        # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -538,7 +538,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -549,7 +549,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -32,24 +32,23 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-# **YAR** - ADD - Selector for devices to choose from
+      # **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-# **YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
+          # **YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
           filter:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI remote control
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI remote control (E1524/E1810)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI remote control
@@ -57,7 +56,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI remote control
           multiple: false
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -373,7 +372,7 @@ variables:
       button_down_release: [stop]
       button_center_short: [toggle]
       button_center_long: [press_2_0_0]
-# **YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
+    # **YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
     zigbee2mqtt:
       button_left_short: [arrow_left_click]
       button_left_long: [arrow_left_hold]
@@ -410,12 +409,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -424,7 +423,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -496,7 +495,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: toggle_hold
-# **YAR** - ADD END
+  # **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -508,7 +507,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -522,13 +521,10 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-# **YAR** - ADD END
-       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -538,7 +534,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -549,7 +545,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT V2.0.0 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -29,9 +29,10 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
         device:
@@ -365,6 +366,21 @@ variables:
       button_down_release: [brightness_down_release]
       button_center_short: [toggle]
       button_center_long: [toggle_hold]
+    zigbee2mqtt_v2:
+      button_left_short: [arrow_left_click]
+      button_left_long: [arrow_left_hold]
+      button_left_release: [arrow_left_release]
+      button_right_short: [arrow_right_click]
+      button_right_long: [arrow_right_hold]
+      button_right_release: [arrow_right_release]
+      button_up_short: [brightness_up_click]
+      button_up_long: [brightness_up_hold]
+      button_up_release: [brightness_up_release]
+      button_down_short: [brightness_down_click]
+      button_down_long: [brightness_down_hold]
+      button_down_release: [brightness_down_release]
+      button_center_short: [toggle]
+      button_center_long: [toggle_hold]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_left_short: '{{ actions_mapping[integration_id]["button_left_short"] }}'
@@ -395,6 +411,77 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_click
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_click
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_up_click
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_up_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_up_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_down_click
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_down_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_down_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: toggle
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: toggle_hold
   # trigger for other integrations
   - platform: event
     event_type:
@@ -410,6 +497,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -420,6 +509,7 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -432,6 +522,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2024-12-07
+    ℹ️ Version 2025-01-01
     Update to fix actions and regex for deCONZ
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
   domain: automation

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT V2.0.0 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -36,6 +36,13 @@ blueprint:
       default: ''
       selector:
         device:
+          filter:
+          - integration: mqtt
+            manufacturer: IKEA
+          - integration: zha
+            manufacturer: IKEA of Sweden
+          - integration: deconz
+          multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -398,7 +405,7 @@ variables:
   button_center_short: '{{ actions_mapping[integration_id]["button_center_short"] }}'
   button_center_long: '{{ actions_mapping[integration_id]["button_center_long"] }}'
   # integrations which need to store the previous press event to determine which button was released
-  integrations_with_prev_event_storage: [zha]
+  integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -39,9 +39,13 @@ blueprint:
           filter:
           - integration: mqtt
             manufacturer: IKEA
+            model: TRADFRI remote control (E1524/E1810)
           - integration: zha
             manufacturer: IKEA of Sweden
+            model: TRADFRI remote control
           - integration: deconz
+            manufacturer: IKEA of Sweden
+            model: TRADFRI remote control
           multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -1,11 +1,14 @@
 # Blueprint metadata
 blueprint:
+  domain: automation
+  homeassistant:
+    min_version: 2023.6.0
   name: Controller - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
   description: |
     # Controller - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -18,10 +21,6 @@ blueprint:
     ℹ️ Version 2025-01-01
 
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
-
-  domain: automation
-  homeassistant:
-    min_version: 2023.5.0
   input:
     integration:
       name: (Required) Integration

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -32,15 +32,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
- #**YAR** - ADD END
+# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
- #**YAR** - ADD - Selector for devices to choose from
+# **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
- #**YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
+# **YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -49,7 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI remote control (E1524/E1810)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI remote control
@@ -57,7 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI remote control
           multiple: false
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -373,7 +373,7 @@ variables:
       button_down_release: [stop]
       button_center_short: [toggle]
       button_center_long: [press_2_0_0]
- #**YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
+# **YAR** - https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
     zigbee2mqtt:
       button_left_short: [arrow_left_click]
       button_left_long: [arrow_left_hold]
@@ -410,12 +410,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -424,7 +424,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -496,7 +496,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: toggle_hold
- #**YAR** - ADD END
+# **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -508,7 +508,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -522,13 +522,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
- #**YAR** - ADD END
+# **YAR** - ADD END
        # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
        # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -538,7 +538,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -549,7 +549,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -1,8 +1,6 @@
 # Blueprint metadata
 blueprint:
   domain: automation
-  homeassistant:
-    min_version: 2023.6.0
   name: Controller - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
   description: |
     # Controller - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -38,11 +38,18 @@ blueprint:
         device:
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+#CHANGED - YAR      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
       default: ''
       selector:
-        entity:
-          domain: sensor
+#CHANGED - YAR        entity:
+#CHANGED - YAR          domain: sensor
+        device:
+          filter:
+          - integration: mqtt
+            manufacturer: IKEA
+            model: TRADFRI on/off switch (E1743)
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -233,10 +240,35 @@ mode: restart
 max_exceeded: silent
 trigger:
   # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
+#CHANGED - YAR  - platform: event
+#CHANGED - YAR    event_type: state_changed
+#CHANGED - YAR    event_data:
+#CHANGED - YAR      entity_id: !input controller_entity
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_entity
+    type: action
+    subtype: 'on'
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_entity
+    type: action
+    subtype: 'off'
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_entity
+    type: action
+    subtype: brightness_move_up
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_entity
+    type: action
+    subtype: brightness_move_down
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_entity
+    type: action
+    subtype: brightness_stop
   # trigger for other integrations
   - platform: event
     event_type:
@@ -251,7 +283,8 @@ condition:
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+#CHANGED - YAR        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -261,7 +294,8 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#CHANGED - YAR      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt" or trigger.payload != last_controller_event }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -273,7 +307,8 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+#CHANGED - YAR        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -32,16 +32,16 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-#**YAR** - ADD END
+ #**YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-#**YAR** - ADD - Selector for devices to choose from
+ #**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
           filter:
-#**YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI on/off switch
@@ -49,7 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI on/off switch (E1743)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI on/off switch
@@ -57,7 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI on/off switch
           multiple: false
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -230,7 +230,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [move_1_83]
       button_down_release: [stop]
-#**YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
     zigbee2mqtt:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -251,12 +251,12 @@ variables:
   # build data to send within a controller event
   controller_device: !input controller_device
   controller_entity: !input controller_entity
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -265,7 +265,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -292,7 +292,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
-#**YAR** - ADD END
+ #**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -304,7 +304,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -318,13 +318,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -334,7 +334,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -345,7 +345,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -251,7 +251,7 @@ variables:
 #**YAR** ADD - Logic to handle z2m legacy
 #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
 #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
-  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in [''] }}'
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
 #**YAR** ADD END
 mode: restart

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -1,14 +1,14 @@
 # Blueprint metadata
 blueprint:
   domain: automation
+  homeassistant:
+    min_version: 2023.5.0
   name: Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
-  #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
-  #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
   description: |
     # Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1743 TRÅDFRI On/Off Switch & Dimmer. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -18,10 +18,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025-01-01
-
-  #YAR - ADD END
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+    ℹ️ Version 2025.01.02
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
   input:
     integration:
       name: (Required) Integration
@@ -32,16 +31,20 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
-            - Zigbee2MQTT_V2
-            #YAR - ADD END
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+#**YAR** - ADD END
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
+#**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
           filter:
+          - integration: mqtt
+            manufacturer: IKEA
+            model: TRADFRI on/off switch
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI on/off switch (E1743)
@@ -52,6 +55,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI on/off switch
           multiple: false
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -219,11 +223,11 @@ variables:
       button_down_release: ['2003']
     zha:
       button_up_short: ['on']
-      button_up_long: [move_with_on_off_MoveMode.Up_83]
-      button_up_release: [stop_with_on_off]
+      button_up_long: [move_with_on_off_0_83]
+      button_up_release: [stop]
       button_down_short: ['off']
-      button_down_long: [move_MoveMode.Down_83_0_0]
-      button_down_release: [stop_with_on_off]
+      button_down_long: [move_1_83]
+      button_down_release: [stop]
     zigbee2mqtt:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -231,15 +235,6 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
-    #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
-    zigbee2mqtt_v2:
-      button_up_short: ['on']
-      button_up_long: [brightness_move_up]
-      button_up_release: [brightness_stop]
-      button_down_short: ['off']
-      button_down_long: [brightness_move_down]
-      button_down_release: [brightness_stop]
-    #YAR - ADD END
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_up_short: '{{ actions_mapping[integration_id]["button_up_short"] }}'
@@ -249,24 +244,26 @@ variables:
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # integrations which need to store the previous press event to determine which button was released
-  #YAR - CHANGED  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
-  #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
-  integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
-  #YAR - ADD END
+  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
   # build data to send within a controller event
-  controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_entity: !input controller_entity
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in [''] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
-  # triggers for zigbee2mqtt_V2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -292,7 +289,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
-  #YAR - ADD END
+#**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -304,13 +301,13 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-      #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
+#**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -318,13 +315,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      #YAR - ADD END
+#**YAR** - ADD END
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
-      #YAR - ADD END
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt" or trigger.payload != last_controller_event or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -334,18 +331,18 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-      #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
+#**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      #YAR - ADD END
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -316,11 +316,11 @@ condition:
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
 #**YAR** - ADD END
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
 #**YAR** - Below needed to change if z2m entity or device not sure I got this right
 #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt" or trigger.payload != last_controller_event or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
 #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -37,22 +37,8 @@ blueprint:
             - Zigbee2MQTT_V2
             #YAR - ADD END
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
+      name: (deCONZ, ZHA, Zigbee2MQTT_v2.0.0) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
-      default: ''
-      selector:
-        device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
-    #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-    controller_mqtt:
-      name: (Zigbee2MQTT v2.0.0) Controller MQTT Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
       default: ''
       selector:
         device:
@@ -60,8 +46,18 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI on/off switch (E1743)
+          - integration: zha
+            manufacturer: IKEA of Sweden
+            model: RODRET Dimmer
+          - integration: deconz
           multiple: false
-    #YAR - ADD END
+    controller_entity:
+      name: (Zigbee2MQTT) Controller Entity
+      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+      default: ''
+      selector:
+        entity:
+          domain: sensor
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -259,19 +255,7 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-  controller_mqtt: !input controller_mqtt
-  #YAR - ADD END
-  #YAR - CHANGED  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}
-                  {{controller_entity}}
-                  {% elif integration_id == "zigbee2mqtt_v2" %}
-                  {{controller_mqtt}}
-                  {% else %}
-                  {{controller_device}}
-                  {% endif %}'
-  #YAR - ADD END
+  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
 mode: restart
 max_exceeded: silent
 trigger:
@@ -284,27 +268,27 @@ trigger:
   # triggers for zigbee2mqtt_v2
   - platform: device
     domain: mqtt
-    device_id: !input controller_mqtt
+    device_id: !input controller_device
     type: action
     subtype: 'on'
   - platform: device
     domain: mqtt
-    device_id: !input controller_mqtt
+    device_id: !input controller_device
     type: action
     subtype: 'off'
   - platform: device
     domain: mqtt
-    device_id: !input controller_mqtt
+    device_id: !input controller_device
     type: action
     subtype: brightness_move_up
   - platform: device
     domain: mqtt
-    device_id: !input controller_mqtt
+    device_id: !input controller_device
     type: action
     subtype: brightness_move_down
   - platform: device
     domain: mqtt
-    device_id: !input controller_mqtt
+    device_id: !input controller_device
     type: action
     subtype: brightness_stop
   #YAR - ADD END

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -50,6 +50,8 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI on/off switch
           - integration: deconz
+            manufacturer: IKEA of Sweden
+            model: TRADFRI on/off switch
           multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -32,24 +32,23 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-# **YAR** - ADD - Selector for devices to choose from
+      # **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
           filter:
-# **YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
+          # **YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI on/off switch
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI on/off switch (E1743)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI on/off switch
@@ -57,7 +56,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI on/off switch
           multiple: false
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -230,7 +229,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [move_1_83]
       button_down_release: [stop]
-# **YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
+    # **YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
     zigbee2mqtt:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -251,12 +250,12 @@ variables:
   # build data to send within a controller event
   controller_device: !input controller_device
   controller_entity: !input controller_entity
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -265,7 +264,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -292,7 +291,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
-# **YAR** - ADD END
+  # **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -304,7 +303,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -318,13 +317,10 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -334,7 +330,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -345,7 +341,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -1,7 +1,8 @@
 # Blueprint metadata
 blueprint:
+  domain: automation
   homeassistant:
-    min_version: "2023.6.0"
+    min_version: 2023.6.0
   name: Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
   #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
   #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
@@ -20,11 +21,9 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2025-01-01
+
   #YAR - ADD END
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
-  domain: automation
-  homeassistant:
-    min_version: 2023.5.0
   input:
     integration:
       name: (Required) Integration

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -32,16 +32,16 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
- #**YAR** - ADD END
+# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
- #**YAR** - ADD - Selector for devices to choose from
+# **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
           filter:
- #**YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
+# **YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI on/off switch
@@ -49,7 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI on/off switch (E1743)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI on/off switch
@@ -57,7 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI on/off switch
           multiple: false
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -230,7 +230,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [move_1_83]
       button_down_release: [stop]
- #**YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
+# **YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
     zigbee2mqtt:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -251,12 +251,12 @@ variables:
   # build data to send within a controller event
   controller_device: !input controller_device
   controller_entity: !input controller_entity
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -265,7 +265,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -292,7 +292,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
- #**YAR** - ADD END
+# **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -304,7 +304,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -318,13 +318,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
- #**YAR** - ADD END
+# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -334,7 +334,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -345,7 +345,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -4,12 +4,12 @@ blueprint:
     min_version: "2023.6.0"
   name: Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
   #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
-  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
   description: |
     # Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1743 TRÅDFRI On/Off Switch & Dimmer. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT V2.0.0 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -33,12 +33,12 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+            #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
             - Zigbee2MQTT_V2
             #YAR - ADD END
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_v2.0.0) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
         device:
@@ -264,8 +264,8 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-  # triggers for zigbee2mqtt_v2
+  #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
+  # triggers for zigbee2mqtt_V2
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -303,7 +303,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+      #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
@@ -321,7 +321,7 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+      #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
       - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
       #YAR - ADD END
 action:
@@ -333,7 +333,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+      #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -41,6 +41,7 @@ blueprint:
       selector:
         device:
           filter:
+#**YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI on/off switch
@@ -48,6 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI on/off switch (E1743)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI on/off switch
@@ -228,6 +230,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [move_1_83]
       button_down_release: [stop]
+#**YAR** - https://www.zigbee2mqtt.io/devices/E1743.html#ikea-e1743
     zigbee2mqtt:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -19,7 +19,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2023.10.05
+    ℹ️ Version 2025-01-01
   #YAR - ADD END
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
   domain: automation

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -3,14 +3,13 @@ blueprint:
   homeassistant:
     min_version: "2023.6.0"
   name: Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+  #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   description: |
     # Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1743 TRÅDFRI On/Off Switch & Dimmer. Allows to optionally loop an action on a button long press.
-#YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT V2.0.0 with legacy=false.
-#YAR - ADD END
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -21,6 +20,7 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2023.10.05
+  #YAR - ADD END
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
   domain: automation
   input:
@@ -33,9 +33,9 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+            #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
             - Zigbee2MQTT_V2
-#YAR - ADD END
+            #YAR - ADD END
     controller_device:
       name: (deCONZ, ZHA) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
@@ -49,7 +49,7 @@ blueprint:
       selector:
         entity:
           domain: sensor
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     controller_mqtt:
       name: (Zigbee2MQTT v2.0.0) Controller MQTT Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -61,7 +61,7 @@ blueprint:
             manufacturer: IKEA
             model: TRADFRI on/off switch (E1743)
           multiple: false
-#YAR - ADD END
+    #YAR - ADD END
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -234,7 +234,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     zigbee2mqtt_v2:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -242,7 +242,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
-#YAR - ADD END
+    #YAR - ADD END
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_up_short: '{{ actions_mapping[integration_id]["button_up_short"] }}'
@@ -252,18 +252,18 @@ variables:
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # integrations which need to store the previous press event to determine which button was released
-#YAR - CHANGED  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - CHANGED  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
-#YAR - ADD END
+  #YAR - ADD END
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   controller_mqtt: !input controller_mqtt
-#YAR - ADD END
-#YAR - CHANGED  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD END
+  #YAR - CHANGED  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   controller_id: '{% if integration_id=="zigbee2mqtt" %}
                   {{controller_entity}}
                   {% elif integration_id == "zigbee2mqtt_v2" %}
@@ -271,7 +271,7 @@ variables:
                   {% else %}
                   {{controller_device}}
                   {% endif %}'
-#YAR - ADD END
+  #YAR - ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -280,7 +280,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   # triggers for zigbee2mqtt_v2
   - platform: device
     domain: mqtt
@@ -307,7 +307,7 @@ trigger:
     device_id: !input controller_mqtt
     type: action
     subtype: brightness_stop
-#YAR - ADD END
+  #YAR - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -319,14 +319,13 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
         {%- elif integration_id == "zigbee2mqtt_v2" -%}
         {{ trigger.payload }}
-#YAR - ADD END
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -334,12 +333,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
+      #YAR - ADD END
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
       - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
-#YAR - ADD END
+      #YAR - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -349,18 +349,18 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
         {%- elif integration_id == "zigbee2mqtt_v2" -%}
         {{ trigger.payload }}
-#YAR - ADD END
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
+      #YAR - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -1,8 +1,6 @@
 # Blueprint metadata
 blueprint:
   domain: automation
-  homeassistant:
-    min_version: 2023.6.0
   name: Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
   #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
   #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -48,7 +48,7 @@ blueprint:
             model: TRADFRI on/off switch (E1743)
           - integration: zha
             manufacturer: IKEA of Sweden
-            model: RODRET Dimmer
+            model: TRADFRI on/off switch
           - integration: deconz
           multiple: false
     controller_entity:
@@ -230,7 +230,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
-    #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
     zigbee2mqtt_v2:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -249,7 +249,7 @@ variables:
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # integrations which need to store the previous press event to determine which button was released
   #YAR - CHANGED  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
-  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
   integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
   #YAR - ADD END
   # build data to send within a controller event

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -1,8 +1,6 @@
 # Blueprint metadata
 blueprint:
   domain: automation
-  homeassistant:
-    min_version: 2023.6.0
   name: Controller - IKEA E1744 SYMFONISK Rotary Remote
   description: |
     # Controller - IKEA E1744 SYMFONISK Rotary Remote

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -1,11 +1,14 @@
 # Blueprint metadata
 blueprint:
+  domain: automation
+  homeassistant:
+    min_version: 2023.6.0
   name: Controller - IKEA E1744 SYMFONISK Rotary Remote
   description: |
     # Controller - IKEA E1744 SYMFONISK Rotary Remote
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1744 SYMFONISK Rotary Remote. Allows to optionally loop a custom action during controller rotation.
-    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -15,10 +18,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025.01.03
-    
+    ℹ️ Version 2025-01-01
+
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
-  domain: automation
   input:
     integration:
       name: (Required) Integration

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -32,24 +32,23 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-# **YAR** - ADD - Selector for devices to choose from
+      # **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-# **YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
+          # **YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
           filter:
           - integration: mqtt
             manufacturer: IKEA
             model: SYMFONISK sound remote, gen 1
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: IKEA
             model: SYMFONISK sound remote, gen 1 (E1744)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: SYMFONISK Sound Controller
@@ -57,7 +56,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: SYMFONISK Sound Controller
           multiple: false
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -194,7 +193,7 @@ variables:
       click_short: [toggle]
       click_double: [step_0_1_0, step_StepMode.Up_1_0_0_0]
       click_triple: [step_1_1_0, step_StepMode.Down_1_0_0_0]
-# **YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
+    # **YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
     zigbee2mqtt:
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]
@@ -213,12 +212,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -227,7 +226,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -259,7 +258,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_step_down
-# **YAR** - ADD END
+  # **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -271,7 +270,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -285,13 +284,10 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -301,7 +297,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -312,7 +308,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{\s*((\"a\":\s*\".*\"|\"t\":\s*\d+\.\d+)(,\s*)?){2}\s*\}$")) else "" }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -32,15 +32,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-#**YAR** - ADD END
+ #**YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-#**YAR** - ADD - Selector for devices to choose from
+ #**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-#**YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -49,7 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: SYMFONISK sound remote, gen 1 (E1744)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: SYMFONISK Sound Controller
@@ -57,7 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: SYMFONISK Sound Controller
           multiple: false
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -194,7 +194,7 @@ variables:
       click_short: [toggle]
       click_double: [step_0_1_0, step_StepMode.Up_1_0_0_0]
       click_triple: [step_1_1_0, step_StepMode.Down_1_0_0_0]
-#**YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
     zigbee2mqtt:
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]
@@ -213,12 +213,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -227,7 +227,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -259,7 +259,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_step_down
-#**YAR** - ADD END
+ #**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -271,7 +271,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -285,13 +285,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -301,7 +301,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -312,7 +312,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{\s*((\"a\":\s*\".*\"|\"t\":\s*\d+\.\d+)(,\s*)?){2}\s*\}$")) else "" }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -1,12 +1,14 @@
 # Blueprint metadata
 blueprint:
   domain: automation
+  homeassistant:
+    min_version: 2023.5.0
   name: Controller - IKEA E1744 SYMFONISK Rotary Remote
   description: |
     # Controller - IKEA E1744 SYMFONISK Rotary Remote
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1744 SYMFONISK Rotary Remote. Allows to optionally loop a custom action during controller rotation.
-    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -16,9 +18,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025-01-01
-
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+    ℹ️ Version 2025.01.00
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
   input:
     integration:
       name: (Required) Integration
@@ -29,17 +31,25 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+#**YAR** - ADD END
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
+#**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
+#**YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
           filter:
           - integration: mqtt
             manufacturer: IKEA
+            model: SYMFONISK sound remote, gen 1
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: IKEA
             model: SYMFONISK sound remote, gen 1 (E1744)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: SYMFONISK Sound Controller
@@ -47,6 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: SYMFONISK Sound Controller
           multiple: false
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -177,20 +188,14 @@ variables:
       click_double: ['1004']
       click_triple: ['1005']
     zha:
-      rotate_left: [move_1_195]
-      rotate_stop: [stop]
-      rotate_right: [move_0_195]
+      rotate_left: [move_1_195, move_MoveMode.Down_195_0_0]
+      rotate_stop: [stop, stop_0_0]
+      rotate_right: [move_0_195, move_MoveMode.Up_195_0_0]
       click_short: [toggle]
-      click_double: [step_0_1_0]
-      click_triple: [step_1_1_0]
+      click_double: [step_0_1_0, step_StepMode.Up_1_0_0_0]
+      click_triple: [step_1_1_0, step_StepMode.Down_1_0_0_0]
+#**YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
     zigbee2mqtt:
-      rotate_left: [brightness_move_down]
-      rotate_stop: [brightness_stop]
-      rotate_right: [brightness_move_up]
-      click_short: [toggle]
-      click_double: [brightness_step_up]
-      click_triple: [brightness_step_down]
-    zigbee2mqtt_v2:
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]
       rotate_right: [brightness_move_up]
@@ -208,16 +213,22 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -248,6 +259,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_step_down
+#**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -259,23 +271,27 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
         {%- endset -%}
-        {{ trigger_action not in ["","None","unknown"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+        {{ trigger_action not in ["","None"] }}
+#**YAR** - ADD END
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -285,18 +301,19 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
-      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
+#**YAR** - ADD END
+      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{\s*((\"a\":\s*\".*\"|\"t\":\s*\d+\.\d+)(,\s*)?){2}\s*\}$")) else "" }}'
   # update helper
   - service: input_text.set_value
     data:

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - IKEA E1744 SYMFONISK Rotary Remote
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1744 SYMFONISK Rotary Remote. Allows to optionally loop a custom action during controller rotation.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -28,12 +28,20 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
         device:
+          filter:
+          - integration: mqtt
+            manufacturer: IKEA
+          - integration: zha
+            manufacturer: IKEA of Sweden
+          - integration: deconz
+          multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -177,6 +185,13 @@ variables:
       click_short: [toggle]
       click_double: [brightness_step_up]
       click_triple: [brightness_step_down]
+    zigbee2mqtt_v2:
+      rotate_left: [brightness_move_down]
+      rotate_stop: [brightness_stop]
+      rotate_right: [brightness_move_up]
+      click_short: [toggle]
+      click_double: [brightness_step_up]
+      click_triple: [brightness_step_down]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   rotate_left: '{{ actions_mapping[integration_id]["rotate_left"] }}'
@@ -197,6 +212,37 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+   - platform: device
+     domain: mqtt
+     device_id: !input controller_device
+     type: action
+     subtype: brightness_move_down
+   - platform: device
+     domain: mqtt
+     device_id: !input controller_device
+     type: action
+     subtype: brightness_stop
+   - platform: device
+     domain: mqtt
+     device_id: !input controller_device
+     type: action
+     subtype: brightness_move_up
+   - platform: device
+     domain: mqtt
+     device_id: !input controller_device
+     type: action
+     subtype: toggle
+   - platform: device
+     domain: mqtt
+     device_id: !input controller_device
+     type: action
+     subtype: brightness_step_up
+   - platform: device
+     domain: mqtt
+     device_id: !input controller_device
+     type: action
+     subtype: brightness_step_down
   # trigger for other integrations
   - platform: event
     event_type:
@@ -212,6 +258,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -222,6 +270,7 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -234,6 +283,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -341,3 +392,4 @@ action:
           - choose:
               - conditions: []
                 sequence: !input action_click_triple
+

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025-01-01
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
   domain: automation
   input:
@@ -217,36 +217,36 @@ trigger:
     event_data:
       entity_id: !input controller_entity
   # triggers for zigbee2mqtt_v2
-   - platform: device
-     domain: mqtt
-     device_id: !input controller_device
-     type: action
-     subtype: brightness_move_down
-   - platform: device
-     domain: mqtt
-     device_id: !input controller_device
-     type: action
-     subtype: brightness_stop
-   - platform: device
-     domain: mqtt
-     device_id: !input controller_device
-     type: action
-     subtype: brightness_move_up
-   - platform: device
-     domain: mqtt
-     device_id: !input controller_device
-     type: action
-     subtype: toggle
-   - platform: device
-     domain: mqtt
-     device_id: !input controller_device
-     type: action
-     subtype: brightness_step_up
-   - platform: device
-     domain: mqtt
-     device_id: !input controller_device
-     type: action
-     subtype: brightness_step_down
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_down
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_stop
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_up
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: toggle
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_step_up
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_step_down
   # trigger for other integrations
   - platform: event
     event_type:
@@ -270,7 +270,7 @@ condition:
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
         {%- endset -%}
-        {{ trigger_action not in ["","None"] }}
+        {{ trigger_action not in ["","None","unknown"] }}
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
@@ -396,4 +396,3 @@ action:
           - choose:
               - conditions: []
                 sequence: !input action_click_triple
-

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -32,15 +32,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
- #**YAR** - ADD END
+# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
- #**YAR** - ADD - Selector for devices to choose from
+# **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
- #**YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
+# **YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -49,7 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: SYMFONISK sound remote, gen 1 (E1744)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: SYMFONISK Sound Controller
@@ -57,7 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: SYMFONISK Sound Controller
           multiple: false
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -194,7 +194,7 @@ variables:
       click_short: [toggle]
       click_double: [step_0_1_0, step_StepMode.Up_1_0_0_0]
       click_triple: [step_1_1_0, step_StepMode.Down_1_0_0_0]
- #**YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
+# **YAR** - https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
     zigbee2mqtt:
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]
@@ -213,12 +213,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -227,7 +227,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -259,7 +259,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_step_down
- #**YAR** - ADD END
+# **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -271,7 +271,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -285,13 +285,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
- #**YAR** - ADD END
+# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -301,7 +301,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -312,7 +312,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{\s*((\"a\":\s*\".*\"|\"t\":\s*\d+\.\d+)(,\s*)?){2}\s*\}$")) else "" }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -38,9 +38,13 @@ blueprint:
           filter:
           - integration: mqtt
             manufacturer: IKEA
+            model: SYMFONISK sound remote, gen 1 (E1744)
           - integration: zha
             manufacturer: IKEA of Sweden
+            model: SYMFONISK Sound Controller
           - integration: deconz
+            manufacturer: IKEA of Sweden
+            model: SYMFONISK Sound Controller
           multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -32,15 +32,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-#**YAR** - ADD END
+ #**YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-#**YAR** - ADD - Selector for devices to choose from
+ #**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-#**YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -49,7 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI open/close remote (E1766)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI open/close remote
@@ -57,7 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI open/close remote
           multiple: false
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -173,7 +173,7 @@ variables:
       button_up_release: [stop]
       button_down_short: [down_close]
       button_down_release: [stop]
-#**YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
     zigbee2mqtt:
       button_up_short: [open]
       button_up_release: [stop]
@@ -190,12 +190,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -204,7 +204,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -226,7 +226,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: stop
-#**YAR** - ADD END
+ #**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -238,7 +238,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -252,13 +252,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -268,7 +268,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -279,7 +279,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025-01-01
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
   domain: automation
   input:

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -1,8 +1,6 @@
 # Blueprint metadata
 blueprint:
   domain: automation
-  homeassistant:
-    min_version: 2023.6.0
   name: Controller - IKEA E1766 TRÅDFRI Open/Close Remote
   description: |
     # Controller - IKEA E1766 TRÅDFRI Open/Close Remote

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -32,24 +32,23 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-# **YAR** - ADD - Selector for devices to choose from
+      # **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-# **YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
+          # **YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
           filter:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI open/close remote
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI open/close remote (E1766)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI open/close remote
@@ -57,7 +56,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI open/close remote
           multiple: false
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -173,7 +172,7 @@ variables:
       button_up_release: [stop]
       button_down_short: [down_close]
       button_down_release: [stop]
-# **YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
+    # **YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
     zigbee2mqtt:
       button_up_short: [open]
       button_up_release: [stop]
@@ -190,12 +189,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -204,7 +203,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -226,7 +225,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: stop
-# **YAR** - ADD END
+  # **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -238,7 +237,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -252,13 +251,10 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -268,7 +264,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -279,7 +275,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - IKEA E1766 TRÅDFRI Open/Close Remote
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1766 TRÅDFRI Open/Close Remote.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -28,12 +28,20 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
         device:
+          filter:
+          - integration: mqtt
+            manufacturer: IKEA
+          - integration: zha
+            manufacturer: IKEA of Sweden
+          - integration: deconz
+          multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -154,6 +162,11 @@ variables:
       button_up_release: [stop]
       button_down_short: [close]
       button_down_release: [stop]
+    zigbee2mqtt_v2:
+      button_up_short: [open]
+      button_up_release: [stop]
+      button_down_short: [close]
+      button_down_release: [stop]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_up_short: '{{ actions_mapping[integration_id]["button_up_short"] }}'
@@ -161,7 +174,7 @@ variables:
   button_down_short: '{{ actions_mapping[integration_id]["button_down_short"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # integrations which need to store the previous press event to determine which button was released
-  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
+  integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
@@ -174,6 +187,27 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: open
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: stop
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: close
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: stop
   # trigger for other integrations
   - platform: event
     event_type:
@@ -189,6 +223,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -199,6 +235,7 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -210,6 +247,8 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
+        {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
         {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -38,9 +38,13 @@ blueprint:
           filter:
           - integration: mqtt
             manufacturer: IKEA
+            model: TRADFRI open/close remote (E1766)
           - integration: zha
             manufacturer: IKEA of Sweden
+            model: TRADFRI open/close remote
           - integration: deconz
+            manufacturer: IKEA of Sweden
+            model: TRADFRI open/close remote
           multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -1,11 +1,14 @@
 # Blueprint metadata
 blueprint:
+  domain: automation
+  homeassistant:
+    min_version: 2023.6.0
   name: Controller - IKEA E1766 TRÅDFRI Open/Close Remote
   description: |
     # Controller - IKEA E1766 TRÅDFRI Open/Close Remote
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1766 TRÅDFRI Open/Close Remote.
-    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -16,8 +19,8 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2025-01-01
+
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
-  domain: automation
   input:
     integration:
       name: (Required) Integration
@@ -253,7 +256,7 @@ action:
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "zigbee2mqtt_v2" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -32,15 +32,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
- #**YAR** - ADD END
+# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
- #**YAR** - ADD - Selector for devices to choose from
+# **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
- #**YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
+# **YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -49,7 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI open/close remote (E1766)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI open/close remote
@@ -57,7 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI open/close remote
           multiple: false
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -173,7 +173,7 @@ variables:
       button_up_release: [stop]
       button_down_short: [down_close]
       button_down_release: [stop]
- #**YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
+# **YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
     zigbee2mqtt:
       button_up_short: [open]
       button_up_release: [stop]
@@ -190,12 +190,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -204,7 +204,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -226,7 +226,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: stop
- #**YAR** - ADD END
+# **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -238,7 +238,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -252,13 +252,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
- #**YAR** - ADD END
+# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -268,7 +268,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -279,7 +279,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -1,12 +1,14 @@
 # Blueprint metadata
 blueprint:
   domain: automation
+  homeassistant:
+    min_version: 2023.5.0
   name: Controller - IKEA E1766 TRÅDFRI Open/Close Remote
   description: |
     # Controller - IKEA E1766 TRÅDFRI Open/Close Remote
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1766 TRÅDFRI Open/Close Remote.
-    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -16,9 +18,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025-01-01
-
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
   input:
     integration:
       name: (Required) Integration
@@ -29,17 +31,25 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+#**YAR** - ADD END
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
+#**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
+#**YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
           filter:
           - integration: mqtt
             manufacturer: IKEA
+            model: TRADFRI open/close remote
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: IKEA
             model: TRADFRI open/close remote (E1766)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI open/close remote
@@ -47,6 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI open/close remote
           multiple: false
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -162,12 +173,8 @@ variables:
       button_up_release: [stop]
       button_down_short: [down_close]
       button_down_release: [stop]
+#**YAR** - https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
     zigbee2mqtt:
-      button_up_short: [open]
-      button_up_release: [stop]
-      button_down_short: [close]
-      button_down_release: [stop]
-    zigbee2mqtt_v2:
       button_up_short: [open]
       button_up_release: [stop]
       button_down_short: [close]
@@ -179,20 +186,26 @@ variables:
   button_down_short: '{{ actions_mapping[integration_id]["button_down_short"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # integrations which need to store the previous press event to determine which button was released
-  integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
+  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -213,6 +226,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: stop
+#**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -224,12 +238,13 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -237,10 +252,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+#**YAR** - ADD END
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -250,17 +268,19 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+#**YAR** - ADD END
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -1,8 +1,6 @@
 # Blueprint metadata
 blueprint:
   domain: automation
-  homeassistant:
-    min_version: 2023.6.0
   name: Controller - IKEA E1812 TRÅDFRI Shortcut button
   description: |
     # Controller - IKEA E1812 TRÅDFRI Shortcut button

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -32,24 +32,23 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-# **YAR** - ADD - Selector for devices to choose from
+      # **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-# **YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
+          # **YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
           filter:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI shortcut button
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI shortcut button (E1812)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI SHORTCUT Button
@@ -57,7 +56,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI SHORTCUT Button
           multiple: false
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -173,7 +172,7 @@ variables:
       button_short: ['on']
       button_long: [move_with_on_off_0_83]
       button_release: [stop]
-# **YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
+    # **YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
     zigbee2mqtt:
       button_short: ['on']
       button_long: [brightness_move_up]
@@ -186,12 +185,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -200,7 +199,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -217,7 +216,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
-# **YAR** - ADD END
+  # **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -229,7 +228,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -243,13 +242,10 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -259,7 +255,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -270,7 +266,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -32,15 +32,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-#**YAR** - ADD END
+ #**YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-#**YAR** - ADD - Selector for devices to choose from
+ #**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-#**YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -49,7 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI shortcut button (E1812)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI SHORTCUT Button
@@ -57,7 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI SHORTCUT Button
           multiple: false
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -173,7 +173,7 @@ variables:
       button_short: ['on']
       button_long: [move_with_on_off_0_83]
       button_release: [stop]
-#**YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
     zigbee2mqtt:
       button_short: ['on']
       button_long: [brightness_move_up]
@@ -186,12 +186,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -200,7 +200,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -217,7 +217,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
-#**YAR** - ADD END
+ #**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -229,7 +229,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -243,13 +243,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -259,7 +259,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -270,7 +270,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -32,15 +32,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
- #**YAR** - ADD END
+# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
- #**YAR** - ADD - Selector for devices to choose from
+# **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
- #**YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
+# **YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -49,7 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI shortcut button (E1812)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI SHORTCUT Button
@@ -57,7 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI SHORTCUT Button
           multiple: false
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -173,7 +173,7 @@ variables:
       button_short: ['on']
       button_long: [move_with_on_off_0_83]
       button_release: [stop]
- #**YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
+# **YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
     zigbee2mqtt:
       button_short: ['on']
       button_long: [brightness_move_up]
@@ -186,12 +186,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -200,7 +200,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -217,7 +217,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
- #**YAR** - ADD END
+# **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -229,7 +229,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -243,13 +243,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
- #**YAR** - ADD END
+# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -259,7 +259,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -270,7 +270,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -1,13 +1,14 @@
 # Blueprint metadata
 blueprint:
+  domain: automation
   homeassistant:
-    min_version: "2023.6.0"
+    min_version: 2023.6.0
   name: Controller - IKEA E1812 TRÅDFRI Shortcut button
   description: |
     # Controller - IKEA E1812 TRÅDFRI Shortcut button
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI Shortcut button. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -18,10 +19,8 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2025-01-01
+
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
-  domain: automation
-  homeassistant:
-    min_version: 2023.5.0
   input:
     integration:
       name: (Required) Integration

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -40,9 +40,13 @@ blueprint:
           filter:
           - integration: mqtt
             manufacturer: IKEA
+            model: TRADFRI shortcut button (E1812)
           - integration: zha
             manufacturer: IKEA of Sweden
+            model: TRADFRI SHORTCUT Button
           - integration: deconz
+            manufacturer: IKEA of Sweden
+            model: TRADFRI SHORTCUT Button
           multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -17,7 +17,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2024-12-07
+    ℹ️ Version 2025-01-01
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
   domain: automation
   input:

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -1,12 +1,14 @@
 # Blueprint metadata
 blueprint:
   domain: automation
+  homeassistant:
+    min_version: 2023.5.0
   name: Controller - IKEA E1812 TRÅDFRI Shortcut button
   description: |
     # Controller - IKEA E1812 TRÅDFRI Shortcut button
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI Shortcut button. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -16,9 +18,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025-01-01
-
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+    ℹ️ Version 2025.01.03
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
   input:
     integration:
       name: (Required) Integration
@@ -29,17 +31,25 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+#**YAR** - ADD END
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
+#**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
+#**YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
           filter:
           - integration: mqtt
             manufacturer: IKEA
+            model: TRADFRI shortcut button
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: IKEA
             model: TRADFRI shortcut button (E1812)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI SHORTCUT Button
@@ -47,6 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: TRADFRI SHORTCUT Button
           multiple: false
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -160,13 +171,10 @@ variables:
       button_release: ['1003']
     zha:
       button_short: ['on']
-      button_long: [move_with_on_off_0_83, 'move_with_on_off_MoveMode.Up_83']
-      button_release: [stop, stop_with_on_off]
+      button_long: [move_with_on_off_0_83]
+      button_release: [stop]
+#**YAR** - https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
     zigbee2mqtt:
-      button_short: ['on']
-      button_long: [brightness_move_up]
-      button_release: [brightness_stop]
-    zigbee2mqtt_v2:
       button_short: ['on']
       button_long: [brightness_move_up]
       button_release: [brightness_stop]
@@ -178,16 +186,22 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -203,6 +217,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
+#**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -214,12 +229,13 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -227,10 +243,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+#**YAR** - ADD END
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -240,16 +259,18 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -7,7 +7,7 @@ blueprint:
     # Controller - IKEA E1812 TRÅDFRI Shortcut button
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI Shortcut button. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -30,12 +30,20 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
         device:
+          filter:
+          - integration: mqtt
+            manufacturer: IKEA
+          - integration: zha
+            manufacturer: IKEA of Sweden
+          - integration: deconz
+          multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -155,6 +163,10 @@ variables:
       button_short: ['on']
       button_long: [brightness_move_up]
       button_release: [brightness_stop]
+    zigbee2mqtt_v2:
+      button_short: ['on']
+      button_long: [brightness_move_up]
+      button_release: [brightness_stop]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_short: '{{ actions_mapping[integration_id]["button_short"] }}'
@@ -172,6 +184,22 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'on'
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_up
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_stop
   # trigger for other integrations
   - platform: event
     event_type:
@@ -187,6 +215,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -197,6 +227,7 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -209,6 +240,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/ikea_e1812/ikea_e1812_dru.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812_dru.yaml
@@ -14,7 +14,7 @@ blueprint:
     for additional details.\n\n\U0001F4D5 Full documentation regarding this blueprint
     is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812).\n\n\U0001F680
     This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints)
-    project**.\n\nℹ️ Version 2022.08.08 - modified by removing obsolete helpers relating to calculated double press. See https://github.com/lsismeiro/awesome-ha-blueprints/issues/12#issuecomment-2018106528 \n"
+    project**.\n\nℹ️ Version 2025-01-01 - modified by removing obsolete helpers relating to calculated double press. See https://github.com/lsismeiro/awesome-ha-blueprints/issues/12#issuecomment-2018106528 \n"
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1812/ikea_e1812_dru.yaml
   domain: automation
   input:

--- a/blueprints/controllers/ikea_e1812/ikea_e1812_dru.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812_dru.yaml
@@ -44,9 +44,13 @@ blueprint:
           filter:
           - integration: mqtt
             manufacturer: IKEA
+            model: TRADFRI shortcut button (E1812)
           - integration: zha
             manufacturer: IKEA of Sweden
+            model: TRADFRI SHORTCUT button
           - integration: deconz
+            manufacturer: IKEA of Sweden
+            model: TRADFRI SHORTCUT button
           multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity

--- a/blueprints/controllers/ikea_e1812/ikea_e1812_dru.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812_dru.yaml
@@ -1,8 +1,6 @@
 # Blueprint metadata
 blueprint:
   domain: automation
-  homeassistant:
-    min_version: 2023.6.0
   name: Controller - IKEA E1812 TRÅDFRI Shortcut button [dru]
   description: |
     # Controller - IKEA E1812 TRÅDFRI Shortcut button [dru]

--- a/blueprints/controllers/ikea_e1812/ikea_e1812_dru.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812_dru.yaml
@@ -1,28 +1,30 @@
+# Blueprint metadata
 blueprint:
+  domain: automation
   homeassistant:
     min_version: 2023.6.0
   name: Controller - IKEA E1812 TRÅDFRI Shortcut button [dru]
-  description:
-    "# Controller - IKEA E1812 TRÅDFRI Shortcut button\n\nController automation
-    for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI
-    Shortcut button. Allows to optionally loop an action on a button long press.\nSupports
-    deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.\n\nAutomations created with this blueprint can be connected
-    with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks)
-    supported by this controller.\nHooks allow to easily create controller-based automations
-    for interacting with media players, lights, covers and more.\nSee the list of
-    [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812#available-hooks)
-    for additional details.\n\n\U0001F4D5 Full documentation regarding this blueprint
-    is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812).\n\n\U0001F680
-    This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints)
-    project**.\n\nℹ️ Version 2025-01-01 - modified by removing obsolete helpers relating to calculated double press. See https://github.com/lsismeiro/awesome-ha-blueprints/issues/12#issuecomment-2018106528 \n"
+  description: |
+    # Controller - IKEA E1812 TRÅDFRI Shortcut button [dru]
+
+    Controller automation for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI Shortcut button. Allows to optionally loop an action on a button long press.
+    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
+
+    Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
+    Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
+    See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812#available-hooks) for additional details.
+
+    📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812).
+
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+
+    ℹ️ Version 2025-01-01 - modified by [dru] removing obsolete helpers relating to calculated double press.
+
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1812/ikea_e1812_dru.yaml
-  domain: automation
   input:
     integration:
       name: (Required) Integration
-      description:
-        Integration used for connecting the remote with Home Assistant.
-        Select one of the available values.
+      description: Integration used for connecting the remote with Home Assistant. Select one of the available values.
       selector:
         select:
           options:
@@ -30,15 +32,10 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
             - Zigbee2MQTT_V2
-          custom_value: false
-          sort: false
-          multiple: false
     controller_device:
       name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description:
-        The controller device to use for the automation. Choose a value
-        only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
-      default: ""
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
+      default: ''
       selector:
         device:
           filter:
@@ -54,28 +51,19 @@ blueprint:
           multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
-      description:
-        The action sensor of the controller to use for the automation.
-        Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ""
+      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+      default: ''
       selector:
         entity:
-          domain:
-            - sensor
-          multiple: false
+          domain: sensor
     # helper_last_controller_event:
     #   name: (Required) Helper - Last Controller Event
-    #   description:
-    #     Input Text used to store the last event fired by the controller.
-    #     You will need to manually create a text input entity for this, please read
-    #     the blueprint Additional Notes for more info.
-    #   default: ""
+    #   description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
+    #   default: ''
     #   selector:
     #     entity:
-    #       domain:
-    #         - input_text
-    #       multiple: false
-
+    #       domain: input_text
+    # inputs for custom actions
     action_button_short:
       name: (Optional) Button short press
       description: Action to run on short button press.
@@ -100,6 +88,7 @@ blueprint:
       default: []
       selector:
         action: {}
+    # inputs for looping custom actions on long button press events until the corresponding release event is received
     button_long_loop:
       name: (Optional) Button long press - loop until release
       description: Loop the button action until the button is released.
@@ -108,10 +97,9 @@ blueprint:
         boolean: {}
     button_long_max_loop_repeats:
       name: (Optional) Button long press - Maximum loop repeats
-      description:
-        Maximum number of repeats for the custom action, when looping is
-        enabled. Use it as a safety limit to prevent an endless loop in case the corresponding
-        stop event is not received.
+      description: >-
+        Maximum number of repeats for the custom action, when looping is enabled.
+        Use it as a safety limit to prevent an endless loop in case the corresponding stop event is not received.
       default: 500
       selector:
         number:
@@ -119,22 +107,17 @@ blueprint:
           max: 5000.0
           mode: slider
           step: 1.0
+    ## inputs for enabling double press events
     # button_double_press:
     #   name: (Optional) Expose button double press event
-    #   description:
-    #     Choose whether or not to expose the virtual double press event
-    #     for the button. Turn this on if you are providing an action for the button
-    #     double press event.
+    #   description: Choose whether or not to expose the virtual double press event for the button. Turn this on if you are providing an action for the button double press event.
     #   default: false
     #   selector:
     #     boolean: {}
+    ## helpers used to properly recognize the remote button events
     # helper_double_press_delay:
     #   name: (Optional) Helper - Double Press delay
-    #   description:
-    #     Max delay between the first and the second button press for the
-    #     double press event. Provide a value only if you are using a double press action.
-    #     Increase this value if you notice that the double press action is not triggered
-    #     properly.
+    #   description: Max delay between the first and the second button press for the double press event. Provide a value only if you are using a double press action. Increase this value if you notice that the double press action is not triggered properly.
     #   default: 500
     #   selector:
     #     number:
@@ -372,7 +355,7 @@ action:
           - choose:
               - conditions: []
                 sequence: !input action_button_short
-      
+
       - conditions: "{{ trigger_action | string in button_double }}"
         sequence:
           - event: ahb_controller_event

--- a/blueprints/controllers/ikea_e1812/ikea_e1812_dru.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812_dru.yaml
@@ -6,7 +6,7 @@ blueprint:
     "# Controller - IKEA E1812 TRÅDFRI Shortcut button\n\nController automation
     for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI
     Shortcut button. Allows to optionally loop an action on a button long press.\nSupports
-    deCONZ, ZHA, Zigbee2MQTT.\n\nAutomations created with this blueprint can be connected
+    deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.\n\nAutomations created with this blueprint can be connected
     with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks)
     supported by this controller.\nHooks allow to easily create controller-based automations
     for interacting with media players, lights, covers and more.\nSee the list of
@@ -29,17 +29,25 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
           custom_value: false
           sort: false
           multiple: false
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
       description:
         The controller device to use for the automation. Choose a value
-        only if the remote is integrated with deCONZ, ZHA.
+        only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ""
       selector:
-        device: {}
+        device:
+          filter:
+          - integration: mqtt
+            manufacturer: IKEA
+          - integration: zha
+            manufacturer: IKEA of Sweden
+          - integration: deconz
+          multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description:
@@ -185,6 +193,17 @@ variables:
       #added by dru
       button_double:
         - "off"
+    zigbee2mqtt_v2:
+      button_short:
+        - "on"
+      button_long:
+        - brightness_move_up
+      button_release:
+        - brightness_stop
+
+      #added by dru
+      button_double:
+        - "off"
 
   button_short: '{{ actions_mapping[integration_id]["button_short"] }}'
   button_long: '{{ actions_mapping[integration_id]["button_long"] }}'
@@ -201,10 +220,33 @@ variables:
 mode: restart
 max_exceeded: silent
 trigger:
+  # trigger for zigbee2mqtt
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: "on"
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_up
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_stop
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: "off"
+  # trigger for other integrations
   - platform: event
     event_type:
       - deconz_event
@@ -214,22 +256,34 @@ trigger:
 condition:
   - condition: and
     conditions:
-      - '{%- set trigger_action -%} {%- if integration_id == "zigbee2mqtt" -%} {{ trigger.event.data.new_state.state
-        }} {%- elif integration_id == "deconz" -%} {{ trigger.event.data.event }} {%-
-        elif integration_id == "zha" -%} {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length
-        > 0}}{{ trigger.event.data.args|join("_") }} {%- endif -%} {%- endset -%} {{ trigger_action
-        not in ["","None"] }}'
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state
-        }}'
+      - '{%- set trigger_action -%}
+         {%- if integration_id == "zigbee2mqtt" -%}
+         {{ trigger.event.data.new_state.state}}
+         {%- elif integration_id == "zigbee2mqtt_v2" -%}
+         {{ trigger.payload }}
+         {%- elif integration_id == "deconz" -%}
+         {{ trigger.event.data.event }}
+         {%- elif integration_id == "zha" -%}
+         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }} 
+         {%- endif -%}
+         {%- endset -%}
+         {{ trigger_action not in ["","None"] }}'
+      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
 action:
   - delay:
       milliseconds: !input helper_debounce_delay
   - variables:
       trigger_action:
-        '{%- if integration_id == "zigbee2mqtt" -%} {{ trigger.event.data.new_state.state
-        }} {%- elif integration_id == "deconz" -%} {{ trigger.event.data.event }} {%-
-        elif integration_id == "zha" -%} {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length
-        > 0}}{{ trigger.event.data.args|join("_") }} {%- endif -%}'
+        '{%- if integration_id == "zigbee2mqtt" -%}
+         {{ trigger.event.data.new_state.state }}
+         {%- elif integration_id == "zigbee2mqtt_v2" -%}
+         {{ trigger.payload }}
+         {%- elif integration_id == "deconz" -%}
+         {{ trigger.event.data.event }}
+         {%- elif integration_id == "zha" -%}
+         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }} 
+         {%- endif -%}'
       # trigger_delta:
       #   '{{ (as_timestamp(now()) - ((states(helper_last_controller_event)
       #   | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event)

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -1,13 +1,14 @@
 # Blueprint metadata
 blueprint:
+  domain: automation
   homeassistant:
-    min_version: "2023.6.0"
+    min_version: 2023.6.0
   name: Controller - IKEA E2001/E2002 STYRBAR Remote control
   description: |
     # Controller - IKEA E2001/E2002 STYRBAR Remote control
 
     Controller automation for executing any kind of action triggered by the provided IKEA E2001/E2002 STYRBAR Remote control. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -18,11 +19,8 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints fork](https://github.com/lsismeiro/awesome-ha-blueprints) **.
 
     ℹ️ Version 2025-01-01
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
 
-  domain: automation
-  homeassistant:
-    min_version: 2023.5.0
+  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
   input:
     integration:
       name: (Required) Integration

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -37,6 +37,17 @@ blueprint:
       default: ''
       selector:
         device:
+          filter:
+          - integration: mqtt
+            manufacturer: IKEA
+            model: STYRBAR remote control (E2001/E2002)
+          - integration: zha
+            manufacturer: IKEA of Sweden
+            model: Remote Control N2
+          - integration: deconz
+            manufacturer: IKEA of Sweden
+            model: Remote Control N2
+          multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -1,12 +1,14 @@
 # Blueprint metadata
 blueprint:
   domain: automation
+  homeassistant:
+    min_version: 2023.5.0
   name: Controller - IKEA E2001/E2002 STYRBAR Remote control
   description: |
     # Controller - IKEA E2001/E2002 STYRBAR Remote control
 
     Controller automation for executing any kind of action triggered by the provided IKEA E2001/E2002 STYRBAR Remote control. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -14,11 +16,11 @@ blueprint:
 
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e2001_e2002).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints fork](https://github.com/lsismeiro/awesome-ha-blueprints) **.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025-01-01
-
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+    ℹ️ Version 2025.01.03
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
   input:
     integration:
       name: (Required) Integration
@@ -29,17 +31,25 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+#**YAR** - ADD END
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
+#**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
+#**YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
           filter:
           - integration: mqtt
             manufacturer: IKEA
+            model: STYRBAR remote control
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: IKEA
             model: STYRBAR remote control (E2001/E2002)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: Remote Control N2
@@ -47,6 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: Remote Control N2
           multiple: false
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -335,20 +346,8 @@ variables:
       button_down_long: [move_1_83, move_MoveMode.Down_83_0_0]
       # Kept first parameter for potential backwards compatibility of previous firmware versions
       button_down_release: [stop, stop_with_on_off]
+#**YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
     zigbee2mqtt:
-      button_left_short: [arrow_left_click]
-      button_left_long: [arrow_left_hold]
-      button_left_release: [arrow_left_release]
-      button_right_short: [arrow_right_click]
-      button_right_long: [arrow_right_hold]
-      button_right_release: [arrow_right_release]
-      button_up_short: ['on']
-      button_up_long: [brightness_move_up]
-      button_up_release: [brightness_stop]
-      button_down_short: ['off']
-      button_down_long: [brightness_move_down]
-      button_down_release: [brightness_stop]
-    zigbee2mqtt_v2:
       button_left_short: [arrow_left_click]
       button_left_long: [arrow_left_hold]
       button_left_release: [arrow_left_release]
@@ -376,20 +375,26 @@ variables:
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # integrations which need to store the previous press event to determine which button was released
-  integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
+  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -445,6 +450,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_move_down
+#**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -456,12 +462,13 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -469,10 +476,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None","unknown"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+#**YAR** - ADD END
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -482,16 +492,18 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -5,7 +5,7 @@ blueprint:
   name: Controller - IKEA E2001/E2002 STYRBAR Remote control
   description: |
     # Controller - IKEA E2001/E2002 STYRBAR Remote control
-    
+
     Controller automation for executing any kind of action triggered by the provided IKEA E2001/E2002 STYRBAR Remote control. Allows to optionally loop an action on a button long press.
     Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
 
@@ -17,7 +17,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints fork](https://github.com/lsismeiro/awesome-ha-blueprints) **.
 
-    ℹ️ Version 2024-12-07
+    ℹ️ Version 2025-01-01
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
   domain: automation
   input:

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -5,8 +5,7 @@ blueprint:
   name: Controller - IKEA E2001/E2002 STYRBAR Remote control
   description: |
     # Controller - IKEA E2001/E2002 STYRBAR Remote control
-    *This blueprint is reported to work with IKEA Styrbar (E2001/E2002)*
-
+    
     Controller automation for executing any kind of action triggered by the provided IKEA E2001/E2002 STYRBAR Remote control. Allows to optionally loop an action on a button long press.
     Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
 

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -32,15 +32,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-#**YAR** - ADD END
+ #**YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-#**YAR** - ADD - Selector for devices to choose from
+ #**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-#**YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -49,7 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: STYRBAR remote control (E2001/E2002)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: Remote Control N2
@@ -57,7 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: Remote Control N2
           multiple: false
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -346,7 +346,7 @@ variables:
       button_down_long: [move_1_83, move_MoveMode.Down_83_0_0]
       # Kept first parameter for potential backwards compatibility of previous firmware versions
       button_down_release: [stop, stop_with_on_off]
-#**YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
     zigbee2mqtt:
       button_left_short: [arrow_left_click]
       button_left_long: [arrow_left_hold]
@@ -379,12 +379,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -393,7 +393,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -450,7 +450,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_move_down
-#**YAR** - ADD END
+ #**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -462,7 +462,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -476,13 +476,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None","unknown"] }}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -492,7 +492,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -503,7 +503,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -5,10 +5,10 @@ blueprint:
   name: Controller - IKEA E2001/E2002 STYRBAR Remote control
   description: |
     # Controller - IKEA E2001/E2002 STYRBAR Remote control
-    *This blueprint is reported to work with IKEA Rodret (E2201)*
+    *This blueprint is reported to work with IKEA Styrbar (E2001/E2002)*
 
     Controller automation for executing any kind of action triggered by the provided IKEA E2001/E2002 STYRBAR Remote control. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT V2.0.0 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -31,9 +31,10 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT_v2.0.0) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_v2.0.0.
       default: ''
       selector:
         device:
@@ -336,6 +337,19 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
+    zigbee2mqtt_v2:
+      button_left_short: [arrow_left_click]
+      button_left_long: [arrow_left_hold]
+      button_left_release: [arrow_left_release]
+      button_right_short: [arrow_right_click]
+      button_right_long: [arrow_right_hold]
+      button_right_release: [arrow_right_release]
+      button_up_short: ['on']
+      button_up_long: [brightness_move_up]
+      button_up_release: [brightness_stop]
+      button_down_short: ['off']
+      button_down_long: [brightness_move_down]
+      button_down_release: [brightness_stop]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_left_short: '{{ actions_mapping[integration_id]["button_left_short"] }}'
@@ -351,7 +365,7 @@ variables:
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # integrations which need to store the previous press event to determine which button was released
-  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
+  integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
@@ -364,6 +378,62 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_click
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_click
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'on'
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_up
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_stop
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'off'
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_down
   # trigger for other integrations
   - platform: event
     event_type:
@@ -379,6 +449,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -389,6 +461,7 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_2" or trigger.payload != last_controller_event }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -401,6 +474,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -1,8 +1,6 @@
 # Blueprint metadata
 blueprint:
   domain: automation
-  homeassistant:
-    min_version: 2023.6.0
   name: Controller - IKEA E2001/E2002 STYRBAR Remote control
   description: |
     # Controller - IKEA E2001/E2002 STYRBAR Remote control

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -8,7 +8,7 @@ blueprint:
     *This blueprint is reported to work with IKEA Styrbar (E2001/E2002)*
 
     Controller automation for executing any kind of action triggered by the provided IKEA E2001/E2002 STYRBAR Remote control. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT V2.0.0 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -33,8 +33,8 @@ blueprint:
             - Zigbee2MQTT
             - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_v2.0.0) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_v2.0.0.
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
         device:
@@ -461,7 +461,7 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_2" or trigger.payload != last_controller_event }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -474,7 +474,7 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_2" -%}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
         {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -32,15 +32,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
- #**YAR** - ADD END
+# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
- #**YAR** - ADD - Selector for devices to choose from
+# **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
- #**YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
+# **YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -49,7 +49,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: STYRBAR remote control (E2001/E2002)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: Remote Control N2
@@ -57,7 +57,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: Remote Control N2
           multiple: false
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -346,7 +346,7 @@ variables:
       button_down_long: [move_1_83, move_MoveMode.Down_83_0_0]
       # Kept first parameter for potential backwards compatibility of previous firmware versions
       button_down_release: [stop, stop_with_on_off]
- #**YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
+# **YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
     zigbee2mqtt:
       button_left_short: [arrow_left_click]
       button_left_long: [arrow_left_hold]
@@ -379,12 +379,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -393,7 +393,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -450,7 +450,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_move_down
- #**YAR** - ADD END
+# **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -462,7 +462,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -476,13 +476,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None","unknown"] }}
- #**YAR** - ADD END
+# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -492,7 +492,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -503,7 +503,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -32,24 +32,23 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-# **YAR** - ADD - Selector for devices to choose from
+      # **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-# **YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
+          # **YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
           filter:
           - integration: mqtt
             manufacturer: IKEA
             model: STYRBAR remote control
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: IKEA
             model: STYRBAR remote control (E2001/E2002)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: Remote Control N2
@@ -57,7 +56,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: Remote Control N2
           multiple: false
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -346,7 +345,7 @@ variables:
       button_down_long: [move_1_83, move_MoveMode.Down_83_0_0]
       # Kept first parameter for potential backwards compatibility of previous firmware versions
       button_down_release: [stop, stop_with_on_off]
-# **YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
+    # **YAR** - https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
     zigbee2mqtt:
       button_left_short: [arrow_left_click]
       button_left_long: [arrow_left_hold]
@@ -379,12 +378,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -393,7 +392,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -450,7 +449,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_move_down
-# **YAR** - ADD END
+  # **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -462,7 +461,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -476,13 +475,10 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None","unknown"] }}
-# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -492,7 +488,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -503,7 +499,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -2,11 +2,11 @@
 blueprint:
   homeassistant:
     min_version: "2023.6.0"
-  name: Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+  name: Controller - IKEA E2201 RODRET Dimmer
   description: |
-    # Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+    # Controller - IKEA E2201 RODRET Dimmer
 
-    Controller automation for executing any kind of action triggered by the provided IKEA E1743 TRÅDFRI On/Off Switch & Dimmer. Allows to optionally loop an action on a button long press.
+    Controller automation for executing any kind of action triggered by the provided IKEA E2201 RODRET Dimmer. Allows to optionally loop an action on a button long press.
 #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
 #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT V2.0.0 with legacy=false.
@@ -59,7 +59,7 @@ blueprint:
           filter:
           - integration: mqtt
             manufacturer: IKEA
-            model: TRADFRI on/off switch (E1743)
+            model: RODRET wireless dimmer/power switch (E2201)
           multiple: false
 #YAR - ADD END
     helper_last_controller_event:

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -1,7 +1,8 @@
 # Blueprint metadata
 blueprint:
+  domain: automation
   homeassistant:
-    min_version: "2023.6.0"
+    min_version: 2023.6.0
   name: Controller - IKEA E2201 RODRET Dimmer
   #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
   #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
@@ -21,8 +22,8 @@ blueprint:
 
     ℹ️ Version 2025-01-01
   #YAR - ADD END
+
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
-  domain: automation
   input:
     integration:
       name: (Required) Integration

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -3,14 +3,13 @@ blueprint:
   homeassistant:
     min_version: "2023.6.0"
   name: Controller - IKEA E2201 RODRET Dimmer
+  #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   description: |
     # Controller - IKEA E2201 RODRET Dimmer
 
     Controller automation for executing any kind of action triggered by the provided IKEA E2201 RODRET Dimmer. Allows to optionally loop an action on a button long press.
-#YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT V2.0.0 with legacy=false.
-#YAR - ADD END
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -21,6 +20,7 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2023.10.05
+  #YAR - ADD END
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
   domain: automation
   input:
@@ -33,9 +33,9 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+            #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
             - Zigbee2MQTT_V2
-#YAR - ADD END
+            #YAR - ADD END
     controller_device:
       name: (deCONZ, ZHA) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
@@ -49,7 +49,7 @@ blueprint:
       selector:
         entity:
           domain: sensor
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     controller_mqtt:
       name: (Zigbee2MQTT v2.0.0) Controller MQTT Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -61,7 +61,7 @@ blueprint:
             manufacturer: IKEA
             model: RODRET wireless dimmer/power switch (E2201)
           multiple: false
-#YAR - ADD END
+    #YAR - ADD END
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -234,7 +234,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
     zigbee2mqtt_v2:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -242,7 +242,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
-#YAR - ADD END
+    #YAR - ADD END
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_up_short: '{{ actions_mapping[integration_id]["button_up_short"] }}'
@@ -252,18 +252,18 @@ variables:
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # integrations which need to store the previous press event to determine which button was released
-#YAR - CHANGED  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - CHANGED  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
-#YAR - ADD END
+  #YAR - ADD END
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   controller_mqtt: !input controller_mqtt
-#YAR - ADD END
-#YAR - CHANGED  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD END
+  #YAR - CHANGED  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   controller_id: '{% if integration_id=="zigbee2mqtt" %}
                   {{controller_entity}}
                   {% elif integration_id == "zigbee2mqtt_v2" %}
@@ -271,7 +271,7 @@ variables:
                   {% else %}
                   {{controller_device}}
                   {% endif %}'
-#YAR - ADD END
+  #YAR - ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -280,7 +280,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
   # triggers for zigbee2mqtt_v2
   - platform: device
     domain: mqtt
@@ -307,7 +307,7 @@ trigger:
     device_id: !input controller_mqtt
     type: action
     subtype: brightness_stop
-#YAR - ADD END
+  #YAR - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -319,14 +319,13 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
         {%- elif integration_id == "zigbee2mqtt_v2" -%}
         {{ trigger.payload }}
-#YAR - ADD END
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -334,12 +333,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
+      #YAR - ADD END
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
       - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
-#YAR - ADD END
+      #YAR - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -349,18 +349,18 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
         {%- elif integration_id == "zigbee2mqtt_v2" -%}
         {{ trigger.payload }}
-#YAR - ADD END
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
+      #YAR - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -4,12 +4,12 @@ blueprint:
     min_version: "2023.6.0"
   name: Controller - IKEA E2201 RODRET Dimmer
   #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
-  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
   description: |
     # Controller - IKEA E2201 RODRET Dimmer
 
     Controller automation for executing any kind of action triggered by the provided IKEA E2201 RODRET Dimmer. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT V2.0.0 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -33,11 +33,11 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+            #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
             - Zigbee2MQTT_V2
             #YAR - ADD END
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_v2.0.0) Controller Device
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
@@ -230,7 +230,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
-    #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
     zigbee2mqtt_v2:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -249,7 +249,7 @@ variables:
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # integrations which need to store the previous press event to determine which button was released
   #YAR - CHANGED  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
-  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
   integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
   #YAR - ADD END
   # build data to send within a controller event
@@ -264,7 +264,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
   # triggers for zigbee2mqtt_v2
   - platform: device
     domain: mqtt
@@ -303,7 +303,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+      #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
@@ -321,7 +321,7 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+      #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
       - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
       #YAR - ADD END
 action:
@@ -333,7 +333,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-      #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+      #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -1,8 +1,6 @@
 # Blueprint metadata
 blueprint:
   domain: automation
-  homeassistant:
-    min_version: 2023.6.0
   name: Controller - IKEA E2201 RODRET Dimmer
   #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
   #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -50,6 +50,8 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: RODRET Dimmer
           - integration: deconz
+            manufacturer: IKEA of Sweden
+            model: RODRET Dimmer
           multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -39,6 +39,7 @@ blueprint:
 #**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
+#**YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -47,6 +48,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: RODRET wireless dimmer/power switch (E2201)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: RODRET Dimmer
@@ -227,6 +229,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [move_MoveMode.Down_83_0_0]
       button_down_release: [stop_with_on_off]
+#**YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
     zigbee2mqtt:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -315,11 +315,11 @@ condition:
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
 #**YAR** - ADD END
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
 #**YAR** - Below needed to change if z2m entity or device not sure I got this right
 #**YAR**- '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt" or trigger.payload != last_controller_event or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
 #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -38,7 +38,7 @@ blueprint:
             #YAR - ADD END
     controller_device:
       name: (deCONZ, ZHA, Zigbee2MQTT_v2.0.0) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
         device:

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -250,7 +250,7 @@ variables:
 #**YAR** ADD - Logic to handle z2m legacy
 #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
 #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
-  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in [''] }}'
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
 #**YAR** ADD END
 mode: restart

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -37,22 +37,8 @@ blueprint:
             - Zigbee2MQTT_V2
             #YAR - ADD END
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
+      name: (deCONZ, ZHA, Zigbee2MQTT_v2.0.0) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
-      default: ''
-      selector:
-        device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
-    #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-    controller_mqtt:
-      name: (Zigbee2MQTT v2.0.0) Controller MQTT Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
       default: ''
       selector:
         device:
@@ -60,8 +46,18 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: RODRET wireless dimmer/power switch (E2201)
+          - integration: zha
+            manufacturer: IKEA of Sweden
+            model: RODRET Dimmer
+          - integration: deconz
           multiple: false
-    #YAR - ADD END
+    controller_entity:
+      name: (Zigbee2MQTT) Controller Entity
+      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+      default: ''
+      selector:
+        entity:
+          domain: sensor
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -259,19 +255,7 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-  controller_mqtt: !input controller_mqtt
-  #YAR - ADD END
-  #YAR - CHANGED  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-  #YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}
-                  {{controller_entity}}
-                  {% elif integration_id == "zigbee2mqtt_v2" %}
-                  {{controller_mqtt}}
-                  {% else %}
-                  {{controller_device}}
-                  {% endif %}'
-  #YAR - ADD END
+  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
 mode: restart
 max_exceeded: silent
 trigger:
@@ -284,27 +268,27 @@ trigger:
   # triggers for zigbee2mqtt_v2
   - platform: device
     domain: mqtt
-    device_id: !input controller_mqtt
+    device_id: !input controller_device
     type: action
     subtype: 'on'
   - platform: device
     domain: mqtt
-    device_id: !input controller_mqtt
+    device_id: !input controller_device
     type: action
     subtype: 'off'
   - platform: device
     domain: mqtt
-    device_id: !input controller_mqtt
+    device_id: !input controller_device
     type: action
     subtype: brightness_move_up
   - platform: device
     domain: mqtt
-    device_id: !input controller_mqtt
+    device_id: !input controller_device
     type: action
     subtype: brightness_move_down
   - platform: device
     domain: mqtt
-    device_id: !input controller_mqtt
+    device_id: !input controller_device
     type: action
     subtype: brightness_stop
   #YAR - ADD END

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -19,7 +19,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2023.10.05
+    ℹ️ Version 2025-01-01
   #YAR - ADD END
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
   domain: automation

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -1,14 +1,14 @@
 # Blueprint metadata
 blueprint:
   domain: automation
+  homeassistant:
+    min_version: 2023.5.0
   name: Controller - IKEA E2201 RODRET Dimmer
-  #YAR - CHANGED    Supports deCONZ, ZHA, Zigbee2MQTT.
-  #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
   description: |
     # Controller - IKEA E2201 RODRET Dimmer
 
     Controller automation for executing any kind of action triggered by the provided IKEA E2201 RODRET Dimmer. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -18,10 +18,8 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025-01-01
-  #YAR - ADD END
-
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+    ℹ️ Version 2025.01.07 - Added support for IKEA RODRET (E2201) - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
   input:
     integration:
       name: (Required) Integration
@@ -32,16 +30,20 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
-            - Zigbee2MQTT_V2
-            #YAR - ADD END
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+#**YAR** - ADD END
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
+#**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
           filter:
+          - integration: mqtt
+            manufacturer: IKEA
+            model: RODRET wireless dimmer/power switch
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: IKEA
             model: RODRET wireless dimmer/power switch (E2201)
@@ -52,6 +54,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: RODRET Dimmer
           multiple: false
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -231,15 +234,6 @@ variables:
       button_down_short: ['off']
       button_down_long: [brightness_move_down]
       button_down_release: [brightness_stop]
-    #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
-    zigbee2mqtt_v2:
-      button_up_short: ['on']
-      button_up_long: [brightness_move_up]
-      button_up_release: [brightness_stop]
-      button_down_short: ['off']
-      button_down_long: [brightness_move_down]
-      button_down_release: [brightness_stop]
-    #YAR - ADD END
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_up_short: '{{ actions_mapping[integration_id]["button_up_short"] }}'
@@ -249,24 +243,26 @@ variables:
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # integrations which need to store the previous press event to determine which button was released
-  #YAR - CHANGED  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
-  #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
-  integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
-  #YAR - ADD END
+  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
   # build data to send within a controller event
-  controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_entity: !input controller_entity
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in [''] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -292,7 +288,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
-  #YAR - ADD END
+#**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -304,13 +300,13 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-      #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
+#**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -318,13 +314,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      #YAR - ADD END
+#**YAR** - ADD END
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
-      #YAR - ADD END
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**- '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt" or trigger.payload != last_controller_event or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -334,18 +330,18 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-      #YAR - ADD - To Support Zigbee2MQTT_V2 with legacy=false
+#**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      #YAR - ADD END
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -31,24 +31,23 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-# **YAR** - ADD - Selector for devices to choose from
+      # **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-# **YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
+          # **YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
           filter:
           - integration: mqtt
             manufacturer: IKEA
             model: RODRET wireless dimmer/power switch
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: IKEA
             model: RODRET wireless dimmer/power switch (E2201)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: RODRET Dimmer
@@ -56,7 +55,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: RODRET Dimmer
           multiple: false
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -229,7 +228,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [move_MoveMode.Down_83_0_0]
       button_down_release: [stop_with_on_off]
-# **YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
+    # **YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
     zigbee2mqtt:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -250,12 +249,12 @@ variables:
   # build data to send within a controller event
   controller_device: !input controller_device
   controller_entity: !input controller_entity
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -264,7 +263,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -291,7 +290,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
-# **YAR** - ADD END
+  # **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -303,7 +302,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -317,13 +316,10 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**- '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -333,7 +329,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -344,7 +340,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -31,15 +31,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-#**YAR** - ADD END
+ #**YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-#**YAR** - ADD - Selector for devices to choose from
+ #**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-#**YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -48,7 +48,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: RODRET wireless dimmer/power switch (E2201)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: RODRET Dimmer
@@ -56,7 +56,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: RODRET Dimmer
           multiple: false
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -229,7 +229,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [move_MoveMode.Down_83_0_0]
       button_down_release: [stop_with_on_off]
-#**YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
+ #**YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
     zigbee2mqtt:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -250,12 +250,12 @@ variables:
   # build data to send within a controller event
   controller_device: !input controller_device
   controller_entity: !input controller_entity
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -264,7 +264,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -291,7 +291,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
-#**YAR** - ADD END
+ #**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -303,7 +303,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -317,13 +317,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**- '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**- '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -333,7 +333,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -344,7 +344,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -31,15 +31,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
- #**YAR** - ADD END
+# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
- #**YAR** - ADD - Selector for devices to choose from
+# **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
- #**YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
+# **YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -48,7 +48,7 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: RODRET wireless dimmer/power switch (E2201)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: RODRET Dimmer
@@ -56,7 +56,7 @@ blueprint:
             manufacturer: IKEA of Sweden
             model: RODRET Dimmer
           multiple: false
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -229,7 +229,7 @@ variables:
       button_down_short: ['off']
       button_down_long: [move_MoveMode.Down_83_0_0]
       button_down_release: [stop_with_on_off]
- #**YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
+# **YAR** - https://www.zigbee2mqtt.io/devices/E2201.html#ikea-e2201
     zigbee2mqtt:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]
@@ -250,12 +250,12 @@ variables:
   # build data to send within a controller event
   controller_device: !input controller_device
   controller_entity: !input controller_entity
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -264,7 +264,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -291,7 +291,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
- #**YAR** - ADD END
+# **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -303,7 +303,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -317,13 +317,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
- #**YAR** - ADD END
+# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**- '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**- '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -333,7 +333,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -344,7 +344,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -30,31 +30,30 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-# **YAR** - ADD - Selector for devices to choose from
+      # **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-# **YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
+          # **YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
           filter:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI wireless dimmer
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI wireless dimmer (ICTC-G-1)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI wireless dimmer
           - integration: deconz
             model: TRADFRI wireless dimmer
           multiple: false
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -167,7 +166,7 @@ variables:
       rotate_left: [move_1_70, move_1_195]
       rotate_stop: [stop]
       rotate_right: [move_with_on_off_0_70, move_with_on_off_0_195]
-# **YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
+    # **YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
     zigbee2mqtt:
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]
@@ -180,12 +179,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -194,7 +193,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -211,7 +210,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_move_up
-# **YAR** - ADD END
+  # **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -223,7 +222,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -237,13 +236,10 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -253,7 +249,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -264,7 +260,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -30,15 +30,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
- #**YAR** - ADD END
+# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
- #**YAR** - ADD - Selector for devices to choose from
+# **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
- #**YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
+# **YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -47,14 +47,14 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI wireless dimmer (ICTC-G-1)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI wireless dimmer
           - integration: deconz
             model: TRADFRI wireless dimmer
           multiple: false
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -167,7 +167,7 @@ variables:
       rotate_left: [move_1_70, move_1_195]
       rotate_stop: [stop]
       rotate_right: [move_with_on_off_0_70, move_with_on_off_0_195]
- #**YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
+# **YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
     zigbee2mqtt:
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]
@@ -180,12 +180,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -194,7 +194,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -211,7 +211,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_move_up
- #**YAR** - ADD END
+# **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -223,7 +223,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -237,13 +237,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
- #**YAR** - ADD END
+# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -253,7 +253,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -264,7 +264,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -1,12 +1,11 @@
 # Blueprint metadata
 blueprint:
-  domain: automation
   name: Controller - IKEA ICTC-G-1 TRÅDFRI wireless dimmer
   description: |
     # Controller - IKEA ICTC-G-1 TRÅDFRI wireless dimmer
 
     Controller automation for executing any kind of action triggered by the provided IKEA ICTC-G-1 TRÅDFRI wireless dimmer. Allows to optionally loop a custom action during controller rotation.
-    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -16,9 +15,10 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025-01-01
-
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+  domain: automation
   input:
     integration:
       name: (Required) Integration
@@ -29,23 +29,32 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+#**YAR** - ADD END
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
+#**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
+#**YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
           filter:
           - integration: mqtt
             manufacturer: IKEA
+            model: TRADFRI wireless dimmer
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: IKEA
             model: TRADFRI wireless dimmer (ICTC-G-1)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI wireless dimmer
           - integration: deconz
             model: TRADFRI wireless dimmer
           multiple: false
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -158,11 +167,8 @@ variables:
       rotate_left: [move_1_70, move_1_195]
       rotate_stop: [stop]
       rotate_right: [move_with_on_off_0_70, move_with_on_off_0_195]
+#**YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
     zigbee2mqtt:
-      rotate_left: [brightness_move_down]
-      rotate_stop: [brightness_stop]
-      rotate_right: [brightness_move_up]
-    zigbee2mqtt_v2:
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]
       rotate_right: [brightness_move_up]
@@ -174,16 +180,22 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -199,6 +211,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_move_up
+#**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -210,12 +223,13 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -223,10 +237,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+#**YAR** - ADD END
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -236,16 +253,18 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - IKEA ICTC-G-1 TRÅDFRI wireless dimmer
 
     Controller automation for executing any kind of action triggered by the provided IKEA ICTC-G-1 TRÅDFRI wireless dimmer. Allows to optionally loop a custom action during controller rotation.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -28,12 +28,20 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
         device:
+          filter:
+          - integration: mqtt
+            manufacturer: IKEA
+          - integration: zha
+            manufacturer: IKEA of Sweden
+          - integration: deconz
+          multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -150,6 +158,10 @@ variables:
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]
       rotate_right: [brightness_move_up]
+    zigbee2mqtt_v2:
+      rotate_left: [brightness_move_down]
+      rotate_stop: [brightness_stop]
+      rotate_right: [brightness_move_up]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   rotate_left: '{{ actions_mapping[integration_id]["rotate_left"] }}'
@@ -167,6 +179,22 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_down
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_stop
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_up
   # trigger for other integrations
   - platform: event
     event_type:
@@ -182,6 +210,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -192,6 +222,7 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -204,6 +235,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -30,15 +30,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-#**YAR** - ADD END
+ #**YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-#**YAR** - ADD - Selector for devices to choose from
+ #**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-#**YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
+ #**YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
           filter:
           - integration: mqtt
             manufacturer: IKEA
@@ -47,14 +47,14 @@ blueprint:
           - integration: mqtt
             manufacturer: IKEA
             model: TRADFRI wireless dimmer (ICTC-G-1)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: IKEA of Sweden
             model: TRADFRI wireless dimmer
           - integration: deconz
             model: TRADFRI wireless dimmer
           multiple: false
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -167,7 +167,7 @@ variables:
       rotate_left: [move_1_70, move_1_195]
       rotate_stop: [stop]
       rotate_right: [move_with_on_off_0_70, move_with_on_off_0_195]
-#**YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
+ #**YAR** - https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
     zigbee2mqtt:
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]
@@ -180,12 +180,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -194,7 +194,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -211,7 +211,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_move_up
-#**YAR** - ADD END
+ #**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -223,7 +223,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -237,13 +237,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -253,7 +253,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -264,7 +264,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -1,8 +1,6 @@
 # Blueprint metadata
 blueprint:
   domain: automation
-  homeassistant:
-    min_version: 2023.6.0
   name: Controller - IKEA ICTC-G-1 TRÅDFRI wireless dimmer
   description: |
     # Controller - IKEA ICTC-G-1 TRÅDFRI wireless dimmer

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -1,11 +1,14 @@
 # Blueprint metadata
 blueprint:
+  domain: automation
+  homeassistant:
+    min_version: 2023.6.0
   name: Controller - IKEA ICTC-G-1 TRÅDFRI wireless dimmer
   description: |
     # Controller - IKEA ICTC-G-1 TRÅDFRI wireless dimmer
 
     Controller automation for executing any kind of action triggered by the provided IKEA ICTC-G-1 TRÅDFRI wireless dimmer. Allows to optionally loop a custom action during controller rotation.
-    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -16,8 +19,8 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2025-01-01
+
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
-  domain: automation
   input:
     integration:
       name: (Required) Integration

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025-01-01
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
   domain: automation
   input:

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -38,9 +38,12 @@ blueprint:
           filter:
           - integration: mqtt
             manufacturer: IKEA
+            model: TRADFRI wireless dimmer (ICTC-G-1)
           - integration: zha
             manufacturer: IKEA of Sweden
+            model: TRADFRI wireless dimmer
           - integration: deconz
+            model: TRADFRI wireless dimmer
           multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity

--- a/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
+++ b/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - OSRAM AC025XX00NJ SMART+ Switch Mini
 
     Controller automation for executing any kind of action triggered by the provided OSRAM AC025XX00NJ SMART+ Switch Mini. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.08.08
+    ℹ️ Version 2024.01.03
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
   domain: automation
   input:
@@ -28,9 +28,10 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
         device:
@@ -273,6 +274,16 @@ variables:
       button_down_short: [down]
       button_down_long: [down_hold]
       button_down_release: [down_release]
+    zigbee2mqtt_v2:
+      button_up_short: [up]
+      button_up_long: [up_hold]
+      button_up_release: [up_release]
+      button_center_short: [circle_click]
+      button_center_long: [circle_hold]
+      button_center_release: [circle_release]
+      button_down_short: [down]
+      button_down_long: [down_hold]
+      button_down_release: [down_release]      
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_up_short: '{{ actions_mapping[integration_id]["button_up_short"] }}'
@@ -296,6 +307,52 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: circle_click
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: circle_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: circle_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_release
   # trigger for other integrations
   - platform: event
     event_type:
@@ -311,6 +368,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -321,6 +380,8 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -333,6 +394,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
+++ b/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - OSRAM AC025XX00NJ SMART+ Switch Mini
 
     Controller automation for executing any kind of action triggered by the provided OSRAM AC025XX00NJ SMART+ Switch Mini. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -15,9 +15,12 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2024.01.03
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
+    ℹ️ Version 2025.01.05
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
   domain: automation
+  homeassistant:
+    min_version: 2023.5.0
   input:
     integration:
       name: (Required) Integration
@@ -28,13 +31,36 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
+#**YAR** - https://www.zigbee2mqtt.io/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.html#osram-ac0251100nj-ac0251600nj-ac0251700nj
+          filter:
+          - integration: mqtt
+            manufacturer: OSRAM
+            model: Smart+ switch mini
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: OSRAM
+            model: Smart+ switch mini (AC0251100NJ/AC0251600NJ/AC0251700NJ)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          - integration: zha
+#**YAR** - TBConfirmed            manufacturer: OSRAM
+#**YAR** - TBConfirmed            model: Lightify Switch Mini
+          - integration: deconz
+#**YAR** - TBConfirmed            manufacturer: OSRAM
+#**YAR** - TBConfirmed            model: Lightify Switch Mini
+          multiple: false
+#      name: (deCONZ, ZHA) Controller Device
+#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+#      default: ''
+#      selector:
+#        device:
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -265,25 +291,16 @@ variables:
       button_down_long: [move]
       button_down_release: [stop]
     zigbee2mqtt:
-      button_up_short: [up]
-      button_up_long: [up_hold]
-      button_up_release: [up_release]
-      button_center_short: [circle_click]
-      button_center_long: [circle_hold]
-      button_center_release: [circle_release]
-      button_down_short: [down]
-      button_down_long: [down_hold]
-      button_down_release: [down_release]
-    zigbee2mqtt_v2:
-      button_up_short: [up]
-      button_up_long: [up_hold]
-      button_up_release: [up_release]
-      button_center_short: [circle_click]
-      button_center_long: [circle_hold]
-      button_center_release: [circle_release]
-      button_down_short: [down]
-      button_down_long: [down_hold]
-      button_down_release: [down_release]      
+      # source: https://www.zigbee2mqtt.io/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.html#actions
+      button_up_short: ['on']
+      button_up_long: [brightness_move_up]
+      button_up_release: [brightness_stop]
+      button_center_short: [brightness_move_to_level]
+      button_center_long: [move_to_saturation]
+      button_center_release: [hue_stop]
+      button_down_short: ['off']
+      button_down_long: [brightness_move_down]
+      button_down_release: [brightness_stop]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_up_short: '{{ actions_mapping[integration_id]["button_up_short"] }}'
@@ -298,46 +315,52 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: up
+    subtype: 'on'
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: up_hold
+    subtype: brightness_move_up
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: up_release
+    subtype: brightness_stop
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: circle_click
+    subtype: brightness_move_to_level
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: circle_hold
+    subtype: move_to_saturation
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: circle_release
+    subtype: hue_stop
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -347,12 +370,18 @@ trigger:
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: down_hold
+    subtype: 'off'
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: down_release
+    subtype: brightness_move_down
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_stop
+#**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -364,24 +393,28 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
+#**YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
-        {{ trigger.event.data.command }}
+        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+#**YAR** - ADD END
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
-
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -391,17 +424,20 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
+#**YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
-        {{ trigger.event.data.command }}
+        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+#**YAR** - ADD END
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:

--- a/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
+++ b/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
@@ -32,13 +32,13 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
- #**YAR** - https://www.zigbee2mqtt.io/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.html#osram-ac0251100nj-ac0251600nj-ac0251700nj
+# **YAR** - https://www.zigbee2mqtt.io/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.html#osram-ac0251100nj-ac0251600nj-ac0251700nj
           filter:
           - integration: mqtt
             manufacturer: OSRAM
@@ -47,20 +47,20 @@ blueprint:
           - integration: mqtt
             manufacturer: OSRAM
             model: Smart+ switch mini (AC0251100NJ/AC0251600NJ/AC0251700NJ)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
- #**YAR** - TBConfirmed            manufacturer: OSRAM
- #**YAR** - TBConfirmed            model: Lightify Switch Mini
+# **YAR** - TBConfirmed            manufacturer: OSRAM
+# **YAR** - TBConfirmed            model: Lightify Switch Mini
           - integration: deconz
- #**YAR** - TBConfirmed            manufacturer: OSRAM
- #**YAR** - TBConfirmed            model: Lightify Switch Mini
+# **YAR** - TBConfirmed            manufacturer: OSRAM
+# **YAR** - TBConfirmed            model: Lightify Switch Mini
           multiple: false
 #      name: (deCONZ, ZHA) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -315,12 +315,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -329,7 +329,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -381,7 +381,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
- #**YAR** - ADD END
+# **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -393,8 +393,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
- #**YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
+# **YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -408,13 +408,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
- #**YAR** - ADD END
+# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -424,8 +424,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
- #**YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
+# **YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -436,7 +436,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
+++ b/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
@@ -32,35 +32,30 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-# **YAR** - https://www.zigbee2mqtt.io/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.html#osram-ac0251100nj-ac0251600nj-ac0251700nj
+          # **YAR** - https://www.zigbee2mqtt.io/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.html#osram-ac0251100nj-ac0251600nj-ac0251700nj
           filter:
           - integration: mqtt
             manufacturer: OSRAM
             model: Smart+ switch mini
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: OSRAM
             model: Smart+ switch mini (AC0251100NJ/AC0251600NJ/AC0251700NJ)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
-# **YAR** - TBConfirmed            manufacturer: OSRAM
-# **YAR** - TBConfirmed            model: Lightify Switch Mini
+          # **YAR** - TBConfirmed manufacturer: OSRAM
+          # **YAR** - TBConfirmed model: Lightify Switch Mini
           - integration: deconz
-# **YAR** - TBConfirmed            manufacturer: OSRAM
-# **YAR** - TBConfirmed            model: Lightify Switch Mini
+          # **YAR** - TBConfirmed manufacturer: OSRAM
+          # **YAR** - TBConfirmed model: Lightify Switch Mini
           multiple: false
-#      name: (deCONZ, ZHA) Controller Device
-#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
-#      default: ''
-#      selector:
-#        device:
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -315,12 +310,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -329,7 +324,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -381,7 +376,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
-# **YAR** - ADD END
+  # **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -393,8 +388,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
-# **YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -408,13 +403,10 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -424,8 +416,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
-# **YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -436,7 +428,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
+++ b/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
@@ -32,13 +32,13 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-#**YAR** - https://www.zigbee2mqtt.io/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.html#osram-ac0251100nj-ac0251600nj-ac0251700nj
+ #**YAR** - https://www.zigbee2mqtt.io/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.html#osram-ac0251100nj-ac0251600nj-ac0251700nj
           filter:
           - integration: mqtt
             manufacturer: OSRAM
@@ -47,20 +47,20 @@ blueprint:
           - integration: mqtt
             manufacturer: OSRAM
             model: Smart+ switch mini (AC0251100NJ/AC0251600NJ/AC0251700NJ)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
-#**YAR** - TBConfirmed            manufacturer: OSRAM
-#**YAR** - TBConfirmed            model: Lightify Switch Mini
+ #**YAR** - TBConfirmed            manufacturer: OSRAM
+ #**YAR** - TBConfirmed            model: Lightify Switch Mini
           - integration: deconz
-#**YAR** - TBConfirmed            manufacturer: OSRAM
-#**YAR** - TBConfirmed            model: Lightify Switch Mini
+ #**YAR** - TBConfirmed            manufacturer: OSRAM
+ #**YAR** - TBConfirmed            model: Lightify Switch Mini
           multiple: false
 #      name: (deCONZ, ZHA) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -315,12 +315,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -329,7 +329,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -381,7 +381,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
-#**YAR** - ADD END
+ #**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -393,8 +393,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
-#**YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -408,13 +408,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -424,8 +424,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
-#**YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** CHECK LATER ZHA        {{ trigger.event.data.command }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -436,7 +436,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -1,8 +1,6 @@
 # Blueprint metadata
 blueprint:
   domain: automation
-  homeassistant:
-    min_version: 2023.6.0
   name: Controller - Philips 324131092621 Hue Dimmer switch
   description: |
     # Controller - Philips 324131092621 Hue Dimmer switch

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - Philips 324131092621 Hue Dimmer switch
 
     Controller automation for executing any kind of action triggered by the provided Philips 324131092621 Hue Dimmer switch. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -1,5 +1,7 @@
 # Blueprint metadata
 blueprint:
+  homeassistant:
+    min_version: "2023.6.0"
   name: Controller - Philips 324131092621 Hue Dimmer switch
   description: |
     # Controller - Philips 324131092621 Hue Dimmer switch
@@ -15,7 +17,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025.01.03
+    ℹ️ Version 2025.01.04
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
   domain: automation
   input:
@@ -361,6 +363,8 @@ variables:
   button_down_short: '{{ actions_mapping[integration_id]["button_down_short"] }}'
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
+  # integrations which need to store the previous press event to determine which button was released
+  integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
@@ -454,7 +458,7 @@ condition:
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
-        {{ trigger.event.data.command }}
+        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
@@ -462,7 +466,6 @@ condition:
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
-
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -480,9 +483,10 @@ action:
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
-        {{ trigger.event.data.command }}
+        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper
   - service: input_text.set_value
     data:
@@ -559,7 +563,10 @@ action:
                       sequence: !input action_button_on_long
             # if looping is not enabled run the custom action only once
             default: !input action_button_on_long
-      - conditions: '{{ trigger_action | string in button_on_release }}'
+      - conditions:
+          - '{{ trigger_action | string in button_on_release }}'
+          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
+          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_on_long }}'
         sequence:
           # fire the event
           - event: ahb_controller_event
@@ -639,7 +646,10 @@ action:
                       sequence: !input action_button_off_long
             # if looping is not enabled run the custom action only once
             default: !input action_button_off_long
-      - conditions: '{{ trigger_action | string in button_off_release }}'
+      - conditions:
+          -'{{ trigger_action | string in button_off_release }}'
+          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
+          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_off_long }}'
         sequence:
           # fire the event
           - event: ahb_controller_event
@@ -719,7 +729,10 @@ action:
                       sequence: !input action_button_up_long
             # if looping is not enabled run the custom action only once
             default: !input action_button_up_long
-      - conditions: '{{ trigger_action | string in button_up_release }}'
+      - conditions:
+          - '{{ trigger_action | string in button_up_release }}'
+          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
+          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_up_long }}'
         sequence:
           # fire the event
           - event: ahb_controller_event
@@ -799,7 +812,10 @@ action:
                       sequence: !input action_button_down_long
             # if looping is not enabled run the custom action only once
             default: !input action_button_down_long
-      - conditions: '{{ trigger_action | string in button_down_release }}'
+      - conditions:
+          - '{{ trigger_action | string in button_down_release }}'
+          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
+          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_down_long }}'
         sequence:
           # fire the event
           - event: ahb_controller_event

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -1,7 +1,8 @@
 # Blueprint metadata
 blueprint:
+  domain: automation
   homeassistant:
-    min_version: "2023.6.0"
+    min_version: 2023.6.0
   name: Controller - Philips 324131092621 Hue Dimmer switch
   description: |
     # Controller - Philips 324131092621 Hue Dimmer switch
@@ -19,7 +20,6 @@ blueprint:
 
     ℹ️ Version 2025.01.04
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
-  domain: automation
   input:
     integration:
       name: (Required) Integration
@@ -382,62 +382,62 @@ trigger:
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: button_on_short
+    subtype: on_press
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: button_on_long
+    subtype: on_hold
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: button_on_release
+    subtype: on_hold_release
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: button_off_short
+    subtype: off_press
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: button_off_long
+    subtype: off_hold
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: button_off_release
+    subtype: off_hold_release
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: button_up_short
+    subtype: up_press
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: button_up_long
+    subtype: up_hold
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: button_up_release
+    subtype: up_hold_release
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: button_down_short
+    subtype: down_press
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: button_down_long
+    subtype: down_hold
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: button_down_release
+    subtype: down_hold_release
   # trigger for other integrations
   - platform: event
     event_type:
@@ -647,7 +647,7 @@ action:
             # if looping is not enabled run the custom action only once
             default: !input action_button_off_long
       - conditions:
-          -'{{ trigger_action | string in button_off_release }}'
+          - '{{ trigger_action | string in button_off_release }}'
           # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
           - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_off_long }}'
         sequence:

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -30,14 +30,14 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
-#**YAR** - https://www.zigbee2mqtt.io/devices/324131092621.html#philips-324131092621
+ #**YAR** - https://www.zigbee2mqtt.io/devices/324131092621.html#philips-324131092621
           - integration: mqtt
             manufacturer: Philips
             model: Hue dimmer switch
@@ -46,20 +46,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Philips
             model: Hue dimmer switch (324131092621)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: Philips
-#**YAR** - TBConfirmed            model: 
+ #**YAR** - TBConfirmed            model: 
           - integration: deconz
             manufacturer: Philips
-#**YAR** - TBConfirmed            model: 
+ #**YAR** - TBConfirmed            model: 
           multiple: false
 #      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -376,12 +376,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -390,7 +390,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -452,7 +452,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: down_hold_release
-#**YAR** ADD END
+ #**YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -464,8 +464,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
-#**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -481,10 +481,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -494,8 +494,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
-#**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -506,7 +506,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2024.07.10
+    ℹ️ Version 2025.01.03
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
   domain: automation
   input:
@@ -28,9 +28,10 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2
       default: ''
       selector:
         device:
@@ -333,6 +334,19 @@ variables:
       button_down_short: [down_press]
       button_down_long: [down_hold]
       button_down_release: [down_hold_release]
+    zigbee2mqtt_v2:
+      button_on_short: [on_press]
+      button_on_long: [on_hold]
+      button_on_release: [on_hold_release]
+      button_off_short: [off_press]
+      button_off_long: [off_hold]
+      button_off_release: [off_hold_release]
+      button_up_short: [up_press]
+      button_up_long: [up_hold]
+      button_up_release: [up_hold_release]
+      button_down_short: [down_press]
+      button_down_long: [down_hold]
+      button_down_release: [down_hold_release]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_on_short: '{{ actions_mapping[integration_id]["button_on_short"] }}'
@@ -359,6 +373,67 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_on_short
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_on_long
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_on_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_off_short
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_off_long
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_off_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_up_short
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_up_long
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_up_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_down_short
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_down_long
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_down_release
   # trigger for other integrations
   - platform: event
     event_type:
@@ -374,6 +449,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -384,6 +461,8 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -396,6 +475,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -6,7 +6,7 @@ blueprint:
     # Controller - Philips 324131092621 Hue Dimmer switch
 
     Controller automation for executing any kind of action triggered by the provided Philips 324131092621 Hue Dimmer switch. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -16,8 +16,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025.01.04
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
   input:
     integration:
       name: (Required) Integration
@@ -28,13 +29,37 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
+          filter:
+#**YAR** - https://www.zigbee2mqtt.io/devices/324131092621.html#philips-324131092621
+          - integration: mqtt
+            manufacturer: Philips
+            model: Hue dimmer switch
+            model_id: 324131092621
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: Philips
+            model: Hue dimmer switch (324131092621)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          - integration: zha
+            manufacturer: Philips
+#**YAR** - TBConfirmed            model: 
+          - integration: deconz
+            manufacturer: Philips
+#**YAR** - TBConfirmed            model: 
+          multiple: false
+#      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+#      default: ''
+#      selector:
+#        device:
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -322,31 +347,18 @@ variables:
       button_down_long: [down_hold]
       button_down_release: [down_long_release]
     zigbee2mqtt:
-      button_on_short: [on_press]
-      button_on_long: [on_hold]
-      button_on_release: [on_hold_release]
-      button_off_short: [off_press]
-      button_off_long: [off_hold]
-      button_off_release: [off_hold_release]
-      button_up_short: [up_press]
-      button_up_long: [up_hold]
-      button_up_release: [up_hold_release]
-      button_down_short: [down_press]
-      button_down_long: [down_hold]
-      button_down_release: [down_hold_release]
-    zigbee2mqtt_v2:
-      button_on_short: [on_press]
-      button_on_long: [on_hold]
-      button_on_release: [on_hold_release]
-      button_off_short: [off_press]
-      button_off_long: [off_hold]
-      button_off_release: [off_hold_release]
-      button_up_short: [up_press]
-      button_up_long: [up_hold]
-      button_up_release: [up_hold_release]
-      button_down_short: [down_press]
-      button_down_long: [down_hold]
-      button_down_release: [down_hold_release]
+      button_on_short: [on-press]
+      button_on_long: [on-hold]
+      button_on_release: [on-hold-release]
+      button_off_short: [off-press]
+      button_off_long: [off-hold]
+      button_off_release: [off-hold-release]
+      button_up_short: [up-press]
+      button_up_long: [up-hold]
+      button_up_release: [up-hold-release]
+      button_down_short: [down-press]
+      button_down_long: [down-hold]
+      button_down_release: [down-hold-release]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_on_short: '{{ actions_mapping[integration_id]["button_on_short"] }}'
@@ -361,21 +373,25 @@ variables:
   button_down_short: '{{ actions_mapping[integration_id]["button_down_short"] }}'
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
-  # integrations which need to store the previous press event to determine which button was released
-  integrations_with_prev_event_storage: [zha, zigbee2mqtt, zigbee2mqtt_v2]
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -436,6 +452,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: down_hold_release
+#**YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -447,23 +464,27 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
+#**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
-        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+        {{ trigger.event.data.command }}
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -473,18 +494,20 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
+#**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
-        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+        {{ trigger.event.data.command }}
         {%- endif -%}
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
-      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper
   - service: input_text.set_value
     data:
@@ -561,10 +584,7 @@ action:
                       sequence: !input action_button_on_long
             # if looping is not enabled run the custom action only once
             default: !input action_button_on_long
-      - conditions:
-          - '{{ trigger_action | string in button_on_release }}'
-          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
-          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_on_long }}'
+      - conditions: '{{ trigger_action | string in button_on_release }}'
         sequence:
           # fire the event
           - event: ahb_controller_event
@@ -644,10 +664,7 @@ action:
                       sequence: !input action_button_off_long
             # if looping is not enabled run the custom action only once
             default: !input action_button_off_long
-      - conditions:
-          - '{{ trigger_action | string in button_off_release }}'
-          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
-          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_off_long }}'
+      - conditions: '{{ trigger_action | string in button_off_release }}'
         sequence:
           # fire the event
           - event: ahb_controller_event
@@ -727,10 +744,7 @@ action:
                       sequence: !input action_button_up_long
             # if looping is not enabled run the custom action only once
             default: !input action_button_up_long
-      - conditions:
-          - '{{ trigger_action | string in button_up_release }}'
-          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
-          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_up_long }}'
+      - conditions: '{{ trigger_action | string in button_up_release }}'
         sequence:
           # fire the event
           - event: ahb_controller_event
@@ -810,10 +824,7 @@ action:
                       sequence: !input action_button_down_long
             # if looping is not enabled run the custom action only once
             default: !input action_button_down_long
-      - conditions:
-          - '{{ trigger_action | string in button_down_release }}'
-          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
-          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_down_long }}'
+      - conditions: '{{ trigger_action | string in button_down_release }}'
         sequence:
           # fire the event
           - event: ahb_controller_event

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -30,14 +30,14 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
- #**YAR** - https://www.zigbee2mqtt.io/devices/324131092621.html#philips-324131092621
+# **YAR** - https://www.zigbee2mqtt.io/devices/324131092621.html#philips-324131092621
           - integration: mqtt
             manufacturer: Philips
             model: Hue dimmer switch
@@ -46,20 +46,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Philips
             model: Hue dimmer switch (324131092621)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: Philips
- #**YAR** - TBConfirmed            model: 
+# **YAR** - TBConfirmed            model: 
           - integration: deconz
             manufacturer: Philips
- #**YAR** - TBConfirmed            model: 
+# **YAR** - TBConfirmed            model: 
           multiple: false
 #      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -376,12 +376,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -390,7 +390,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -452,7 +452,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: down_hold_release
- #**YAR** ADD END
+# **YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -464,8 +464,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
- #**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -481,10 +481,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -494,8 +494,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
- #**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -506,7 +506,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -30,36 +30,31 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
-# **YAR** - https://www.zigbee2mqtt.io/devices/324131092621.html#philips-324131092621
+          # **YAR** - https://www.zigbee2mqtt.io/devices/324131092621.html#philips-324131092621
           - integration: mqtt
             manufacturer: Philips
             model: Hue dimmer switch
             model_id: 324131092621
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: Philips
             model: Hue dimmer switch (324131092621)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: Philips
-# **YAR** - TBConfirmed            model: 
+          # **YAR** - TBConfirmed model: 
           - integration: deconz
             manufacturer: Philips
-# **YAR** - TBConfirmed            model: 
+          # **YAR** - TBConfirmed model: 
           multiple: false
-#      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
-#      default: ''
-#      selector:
-#        device:
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -376,12 +371,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -390,7 +385,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -452,7 +447,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: down_hold_release
-# **YAR** ADD END
+  # **YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -464,8 +459,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
-# **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -481,10 +476,8 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -494,8 +487,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
-# **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -506,7 +499,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/philips_324131137411/philips_324131137411.yaml
+++ b/blueprints/controllers/philips_324131137411/philips_324131137411.yaml
@@ -12,7 +12,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2024.07.10
+    ℹ️ Version 2025.01.03
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_324131137411/philips_324131137411.yaml
   domain: automation
   input:
@@ -25,9 +25,10 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
         device:
@@ -330,6 +331,19 @@ variables:
       button_down_short: [down_press]
       button_down_long: [down_hold]
       button_down_release: [down_hold_release]
+    zigbee2mqtt_v2: # might be incorrect
+      button_on_short: [on_press]
+      button_on_long: [on_hold]
+      button_on_release: [on_hold_release]
+      button_off_short: [off_press]
+      button_off_long: [off_hold]
+      button_off_release: [off_hold_release]
+      button_up_short: [up_press]
+      button_up_long: [up_hold]
+      button_up_release: [up_hold_release]
+      button_down_short: [down_press]
+      button_down_long: [down_hold]
+      button_down_release: [down_hold_release]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_on_short: '{{ actions_mapping[integration_id]["button_on_short"] }}'
@@ -356,6 +370,67 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_press
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_hold_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_press
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_hold_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_press
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_hold_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_press
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_hold_release
   # trigger for other integrations
   - platform: event
     event_type:
@@ -371,6 +446,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -381,6 +458,7 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -393,6 +471,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
+++ b/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
@@ -1,11 +1,14 @@
 # Blueprint metadata
 blueprint:
+  domain: automation
+  homeassistant:
+    min_version: 2023.5.0
   name: Controller - Philips 8718699693985 Hue Smart Button
   description: |
     # Controller - Philips 8718699693985 Hue Smart Button
 
     Controller automation for executing any kind of action triggered by the provided Philips 8718699693985 Hue Smart Button. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -15,9 +18,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.08.08
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
-  domain: automation
+    ℹ️ Version 2025.01.05
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
   input:
     integration:
       name: (Required) Integration
@@ -27,12 +30,44 @@ blueprint:
           options:
             - deCONZ
             - ZHA
+            - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
+          filter:
+#**YAR** - https://www.zigbee2mqtt.io/devices/8718699693985.html#philips-8718699693985
+          - integration: mqtt
+            manufacturer: Philips
+            model: Hue smart button
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: Philips
+            model: Hue smart button (8718699693985)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          - integration: zha
+            manufacturer: Philips
+#**YAR** - TBConfirmed            model: 
+          - integration: deconz
+            manufacturer: Philips
+#**YAR** - TBConfirmed            model: 
+          multiple: false
+#      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+#      default: ''
+#      selector:
+#        device:
+#**YAR** - ADD END
+    controller_entity:
+      name: (Zigbee2MQTT) Controller Entity
+      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+      default: ''
+      selector:
+        entity:
+          domain: sensor
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -141,17 +176,61 @@ variables:
       button_short: [on_short_release]
       button_long: [on_hold]
       button_release: [on_long_release]
+    zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/8718699693985.html#action-enum
+      button_short: ['on', 'off', press]
+      button_long: [hold]
+      button_release: [release]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_short: '{{ actions_mapping[integration_id]["button_short"] }}'
   button_long: '{{ actions_mapping[integration_id]["button_long"] }}'
   button_release: '{{ actions_mapping[integration_id]["button_release"] }}'
   # build data to send within a controller event
+  controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{{controller_device}}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
+  - platform: event
+    event_type: state_changed
+    event_data:
+      entity_id: !input controller_entity
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'on'
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'off'
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: press
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: release
+#**YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -161,17 +240,27 @@ trigger:
       device_id: !input controller_device
 condition:
   # check that the button event is not empty
-  - >-
-    {%- set trigger_action -%}
-    {%- if integration_id == "zigbee2mqtt" -%}
-    {{ trigger.event.data.new_state.state }}
-    {%- elif integration_id == "deconz" -%}
-    {{ trigger.event.data.event }}
-    {%- elif integration_id == "zha" -%}
-    {{ trigger.event.data.command }}
-    {%- endif -%}
-    {%- endset -%}
-    {{ trigger_action not in ["","None"] }}
+#**YAR** - ADD zigbee2mqtt checks for device or entity
+#**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      - >-
+        {%- set trigger_action -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
+        {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "deconz" -%}
+        {{ trigger.event.data.event }}
+        {%- elif integration_id == "zha" -%}
+        {{ trigger.event.data.command }}
+        {%- endif -%}
+        {%- endset -%}
+        {{ trigger_action not in ["","None"] }}
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -181,15 +270,20 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
+#**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
+        {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
         {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+#**YAR** - ADD END
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:

--- a/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
+++ b/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
@@ -32,35 +32,30 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
-# **YAR** - https://www.zigbee2mqtt.io/devices/8718699693985.html#philips-8718699693985
+          # **YAR** - https://www.zigbee2mqtt.io/devices/8718699693985.html#philips-8718699693985
           - integration: mqtt
             manufacturer: Philips
             model: Hue smart button
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: Philips
             model: Hue smart button (8718699693985)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: Philips
-# **YAR** - TBConfirmed            model: 
+          # **YAR** - TBConfirmed model: 
           - integration: deconz
             manufacturer: Philips
-# **YAR** - TBConfirmed            model: 
+          # **YAR** - TBConfirmed model: 
           multiple: false
-#      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
-#      default: ''
-#      selector:
-#        device:
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -189,12 +184,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -203,7 +198,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -230,7 +225,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: release
-# **YAR** ADD END
+  # **YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -240,8 +235,8 @@ trigger:
       device_id: !input controller_device
 condition:
   # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
-# **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+  # **YAR** - ADD zigbee2mqtt checks for device or entity
+  # **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -257,10 +252,8 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -270,8 +263,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
-# **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -282,7 +275,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
+++ b/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
@@ -32,14 +32,14 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
- #**YAR** - https://www.zigbee2mqtt.io/devices/8718699693985.html#philips-8718699693985
+# **YAR** - https://www.zigbee2mqtt.io/devices/8718699693985.html#philips-8718699693985
           - integration: mqtt
             manufacturer: Philips
             model: Hue smart button
@@ -47,20 +47,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Philips
             model: Hue smart button (8718699693985)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: Philips
- #**YAR** - TBConfirmed            model: 
+# **YAR** - TBConfirmed            model: 
           - integration: deconz
             manufacturer: Philips
- #**YAR** - TBConfirmed            model: 
+# **YAR** - TBConfirmed            model: 
           multiple: false
 #      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -189,12 +189,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -203,7 +203,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -230,7 +230,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: release
- #**YAR** ADD END
+# **YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -240,8 +240,8 @@ trigger:
       device_id: !input controller_device
 condition:
   # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
- #**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -257,10 +257,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -270,8 +270,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
- #**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -282,7 +282,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
+++ b/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
@@ -32,14 +32,14 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
-#**YAR** - https://www.zigbee2mqtt.io/devices/8718699693985.html#philips-8718699693985
+ #**YAR** - https://www.zigbee2mqtt.io/devices/8718699693985.html#philips-8718699693985
           - integration: mqtt
             manufacturer: Philips
             model: Hue smart button
@@ -47,20 +47,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Philips
             model: Hue smart button (8718699693985)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: Philips
-#**YAR** - TBConfirmed            model: 
+ #**YAR** - TBConfirmed            model: 
           - integration: deconz
             manufacturer: Philips
-#**YAR** - TBConfirmed            model: 
+ #**YAR** - TBConfirmed            model: 
           multiple: false
 #      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -189,12 +189,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -203,7 +203,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -230,7 +230,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: release
-#**YAR** ADD END
+ #**YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -240,8 +240,8 @@ trigger:
       device_id: !input controller_device
 condition:
   # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
-#**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -257,10 +257,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -270,8 +270,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
-#**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -282,7 +282,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -1,11 +1,12 @@
 # Blueprint metadata
 blueprint:
+  domain: automation
   name: Controller - Philips 929002398602 Hue Dimmer switch v2
   description: |
     # Controller - Philips 929002398602 Hue Dimmer switch v2
 
     Controller automation for executing any kind of action triggered by the provided Philips 929002398602 Hue Dimmer switch v2. Allows to optionally loop an action on a button long press.
-    Supports ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
+    Supports ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -15,9 +16,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025.01.03
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
-  domain: automation
+    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
   input:
     integration:
       name: (Required) Integration
@@ -27,13 +28,37 @@ blueprint:
           options:
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with ZHA, Zigbee2MQTT_V2.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
+          filter:
+#**YAR** - https://www.zigbee2mqtt.io/devices/929002398602.html#philips-929002398602
+          - integration: mqtt
+            manufacturer: Philips
+            model: Hue dimmer switch
+            model_id: 929002398602
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: Philips
+            model: Hue dimmer switch (929002398602)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          - integration: zha
+            manufacturer: Philips
+#**YAR** - TBConfirmed            model: 
+          - integration: deconz
+            manufacturer: Philips
+#**YAR** - TBConfirmed            model: 
+          multiple: false
+#      name: (ZHA, Zigbee2MQTT) Controller Device
+#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+#      default: ''
+#      selector:
+#        device:
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -320,19 +345,6 @@ variables:
       button_down_short: [down_press]
       button_down_long: [down_hold]
       button_down_release: [down_hold_release]
-    zigbee2mqtt_v2:
-      button_on_short: [on_press, on_press_release]
-      button_on_long: [on_hold]
-      button_on_release: [on_hold_release]
-      button_off_short: [off_press, off_press_release]
-      button_off_long: [off_hold]
-      button_off_release: [off_hold_release]
-      button_up_short: [up_press]
-      button_up_long: [up_hold]
-      button_up_release: [up_hold_release]
-      button_down_short: [down_press]
-      button_down_long: [down_hold]
-      button_down_release: [down_hold_release]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_on_short: '{{ actions_mapping[integration_id]["button_on_short"] }}'
@@ -350,16 +362,22 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -409,7 +427,7 @@ trigger:
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: up_hold_
+    subtype: up_hold
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -430,6 +448,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: down_hold_release
+#**YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -440,12 +459,14 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
+#**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -453,11 +474,12 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
-
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -467,16 +489,19 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
+#**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -29,36 +29,31 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
-# **YAR** - https://www.zigbee2mqtt.io/devices/929002398602.html#philips-929002398602
+          # **YAR** - https://www.zigbee2mqtt.io/devices/929002398602.html#philips-929002398602
           - integration: mqtt
             manufacturer: Philips
             model: Hue dimmer switch
             model_id: 929002398602
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: Philips
             model: Hue dimmer switch (929002398602)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: Philips
-# **YAR** - TBConfirmed            model: 
+          # **YAR** - TBConfirmed model: 
           - integration: deconz
             manufacturer: Philips
-# **YAR** - TBConfirmed            model: 
+          # **YAR** - TBConfirmed model: 
           multiple: false
-#      name: (ZHA, Zigbee2MQTT) Controller Device
-#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
-#      default: ''
-#      selector:
-#        device:
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -362,12 +357,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -376,7 +371,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -448,7 +443,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: down_hold_release
-# **YAR** ADD END
+  # **YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -459,8 +454,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
-# **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -476,10 +471,8 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -489,8 +482,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
-# **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -501,7 +494,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -29,14 +29,14 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
- #**YAR** - https://www.zigbee2mqtt.io/devices/929002398602.html#philips-929002398602
+# **YAR** - https://www.zigbee2mqtt.io/devices/929002398602.html#philips-929002398602
           - integration: mqtt
             manufacturer: Philips
             model: Hue dimmer switch
@@ -45,20 +45,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Philips
             model: Hue dimmer switch (929002398602)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: Philips
- #**YAR** - TBConfirmed            model: 
+# **YAR** - TBConfirmed            model: 
           - integration: deconz
             manufacturer: Philips
- #**YAR** - TBConfirmed            model: 
+# **YAR** - TBConfirmed            model: 
           multiple: false
 #      name: (ZHA, Zigbee2MQTT) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -362,12 +362,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -376,7 +376,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -448,7 +448,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: down_hold_release
- #**YAR** ADD END
+# **YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -459,8 +459,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
- #**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -476,10 +476,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -489,8 +489,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
- #**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -501,7 +501,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - Philips 929002398602 Hue Dimmer switch v2
 
     Controller automation for executing any kind of action triggered by the provided Philips 929002398602 Hue Dimmer switch v2. Allows to optionally loop an action on a button long press.
-    Supports ZHA, Zigbee2MQTT.
+    Supports ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025.01.03
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
   domain: automation
   input:
@@ -27,9 +27,10 @@ blueprint:
           options:
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
       name: (ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with ZHA.
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
         device:
@@ -319,6 +320,19 @@ variables:
       button_down_short: [down_press]
       button_down_long: [down_hold]
       button_down_release: [down_hold_release]
+    zigbee2mqtt_v2:
+      button_on_short: [on_press, on_press_release]
+      button_on_long: [on_hold]
+      button_on_release: [on_hold_release]
+      button_off_short: [off_press, off_press_release]
+      button_off_long: [off_hold]
+      button_off_release: [off_hold_release]
+      button_up_short: [up_press]
+      button_up_long: [up_hold]
+      button_up_release: [up_hold_release]
+      button_down_short: [down_press]
+      button_down_long: [down_hold]
+      button_down_release: [down_hold_release]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_on_short: '{{ actions_mapping[integration_id]["button_on_short"] }}'
@@ -345,6 +359,77 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_press
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_press_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_hold_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_press
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_press_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_hold_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_press
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_hold_
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_hold_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_press
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_hold_release
   # trigger for other integrations
   - platform: event
     event_type:
@@ -359,6 +444,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -369,6 +456,8 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -381,6 +470,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -29,14 +29,14 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
-#**YAR** - https://www.zigbee2mqtt.io/devices/929002398602.html#philips-929002398602
+ #**YAR** - https://www.zigbee2mqtt.io/devices/929002398602.html#philips-929002398602
           - integration: mqtt
             manufacturer: Philips
             model: Hue dimmer switch
@@ -45,20 +45,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Philips
             model: Hue dimmer switch (929002398602)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: Philips
-#**YAR** - TBConfirmed            model: 
+ #**YAR** - TBConfirmed            model: 
           - integration: deconz
             manufacturer: Philips
-#**YAR** - TBConfirmed            model: 
+ #**YAR** - TBConfirmed            model: 
           multiple: false
 #      name: (ZHA, Zigbee2MQTT) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -362,12 +362,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -376,7 +376,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -448,7 +448,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: down_hold_release
-#**YAR** ADD END
+ #**YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -459,8 +459,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
-#**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -476,10 +476,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -489,8 +489,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
-#**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** - NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -501,7 +501,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - SONOFF SNZB-01 Wireless Switch
 
     Controller automation for executing any kind of action triggered by the provided SONOFF SNZB-01 Wireless Switch.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -28,12 +28,18 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
       default: ''
       selector:
         device:
+          filter:
+          - integration: mqtt
+          - integration: zha
+          - integration: deconz
+          multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -103,6 +109,10 @@ variables:
       button_short: [single]
       button_long: [long]
       button_double: [double]
+    zigbee2mqtt_v2:
+      button_short: [single]
+      button_long: [long]
+      button_double: [double]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_short: '{{ actions_mapping[integration_id]["button_short"] }}'
@@ -120,6 +130,22 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: single
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: long
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: double
   # trigger for other integrations
   - platform: event
     event_type:
@@ -135,6 +161,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -145,6 +173,7 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -157,6 +186,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025-01-01
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
   domain: automation
   input:

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -1,11 +1,14 @@
 # Blueprint metadata
 blueprint:
+  domain: automation
+  homeassistant:
+    min_version: 2023.6.0
   name: Controller - SONOFF SNZB-01 Wireless Switch
   description: |
     # Controller - SONOFF SNZB-01 Wireless Switch
 
     Controller automation for executing any kind of action triggered by the provided SONOFF SNZB-01 Wireless Switch.
-    Supports deCONZ, ZHA, Zigbee2MQTT, Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -16,8 +19,8 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2025-01-01
+
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
-  domain: automation
   input:
     integration:
       name: (Required) Integration

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -30,24 +30,23 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-# **YAR** - ADD - Selector for devices to choose from
+      # **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-# **YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
+          # **YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
           filter:
           - integration: mqtt
             manufacturer: eWeLink
             model: Wireless button
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: eWeLink
             model: Wireless button (SNZB-01)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: eWeLink
             model: WB01
@@ -55,7 +54,7 @@ blueprint:
             manufacturer: eWeLink
             model: WB01
           multiple: false
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -121,7 +120,7 @@ variables:
       button_short: [toggle]
       button_long: ['off']
       button_double: ['on']
-# **YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
+    # **YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
     zigbee2mqtt:
       button_short: [single]
       button_long: [long]
@@ -134,12 +133,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -148,7 +147,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -165,7 +164,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: double
-# **YAR** ADD END
+  # **YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -177,7 +176,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -191,13 +190,10 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -207,7 +203,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -218,7 +214,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -30,15 +30,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
- #**YAR** - ADD END
+# **YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
- #**YAR** - ADD - Selector for devices to choose from
+# **YAR** - ADD - Selector for devices to choose from
       selector:
         device:
- #**YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
+# **YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
           filter:
           - integration: mqtt
             manufacturer: eWeLink
@@ -47,7 +47,7 @@ blueprint:
           - integration: mqtt
             manufacturer: eWeLink
             model: Wireless button (SNZB-01)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: eWeLink
             model: WB01
@@ -55,7 +55,7 @@ blueprint:
             manufacturer: eWeLink
             model: WB01
           multiple: false
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -121,7 +121,7 @@ variables:
       button_short: [toggle]
       button_long: ['off']
       button_double: ['on']
- #**YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
+# **YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
     zigbee2mqtt:
       button_short: [single]
       button_long: [long]
@@ -134,12 +134,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -148,7 +148,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -165,7 +165,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: double
- #**YAR** ADD END
+# **YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -177,7 +177,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -191,13 +191,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
- #**YAR** - ADD END
+# **YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -207,7 +207,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -218,7 +218,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -6,7 +6,7 @@ blueprint:
     # Controller - SONOFF SNZB-01 Wireless Switch
 
     Controller automation for executing any kind of action triggered by the provided SONOFF SNZB-01 Wireless Switch.
-    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -16,9 +16,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025-01-01
-
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
   input:
     integration:
       name: (Required) Integration
@@ -29,17 +29,25 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+#**YAR** - ADD END
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
+#**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
+#**YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
           filter:
           - integration: mqtt
             manufacturer: eWeLink
+            model: Wireless button
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: eWeLink
             model: Wireless button (SNZB-01)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: eWeLink
             model: WB01
@@ -47,6 +55,7 @@ blueprint:
             manufacturer: eWeLink
             model: WB01
           multiple: false
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -112,11 +121,8 @@ variables:
       button_short: [toggle]
       button_long: ['off']
       button_double: ['on']
+#**YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
     zigbee2mqtt:
-      button_short: [single]
-      button_long: [long]
-      button_double: [double]
-    zigbee2mqtt_v2:
       button_short: [single]
       button_long: [long]
       button_double: [double]
@@ -128,16 +134,22 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -153,6 +165,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: double
+#**YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -164,12 +177,13 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -177,10 +191,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+#**YAR** - ADD END
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -190,16 +207,18 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -30,15 +30,15 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-#**YAR** - ADD END
+ #**YAR** - ADD END
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
-#**YAR** - ADD - Selector for devices to choose from
+ #**YAR** - ADD - Selector for devices to choose from
       selector:
         device:
-#**YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
+ #**YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
           filter:
           - integration: mqtt
             manufacturer: eWeLink
@@ -47,7 +47,7 @@ blueprint:
           - integration: mqtt
             manufacturer: eWeLink
             model: Wireless button (SNZB-01)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
             manufacturer: eWeLink
             model: WB01
@@ -55,7 +55,7 @@ blueprint:
             manufacturer: eWeLink
             model: WB01
           multiple: false
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -121,7 +121,7 @@ variables:
       button_short: [toggle]
       button_long: ['off']
       button_double: ['on']
-#**YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
+ #**YAR** - https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
     zigbee2mqtt:
       button_short: [single]
       button_long: [long]
@@ -134,12 +134,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -148,7 +148,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -165,7 +165,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: double
-#**YAR** ADD END
+ #**YAR** ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -177,7 +177,7 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -191,13 +191,13 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -207,7 +207,7 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -218,7 +218,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -37,8 +37,14 @@ blueprint:
         device:
           filter:
           - integration: mqtt
+            manufacturer: eWeLink
+            model: Wireless button (SNZB-01)
           - integration: zha
+            manufacturer: eWeLink
+            model: WB01
           - integration: deconz
+            manufacturer: eWeLink
+            model: WB01
           multiple: false
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -1,8 +1,6 @@
 # Blueprint metadata
 blueprint:
   domain: automation
-  homeassistant:
-    min_version: 2023.6.0
   name: Controller - SONOFF SNZB-01 Wireless Switch
   description: |
     # Controller - SONOFF SNZB-01 Wireless Switch

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
@@ -30,14 +30,14 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
-#**YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG11LM.html#aqara-wxcjkg11lm
+ #**YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG11LM.html#aqara-wxcjkg11lm
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (single band)
@@ -45,20 +45,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (single band) (WXCJKG11LM)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
-#**YAR** - TBConfirmed            manufacturer: Xiaomi
-#**YAR** - TBConfirmed            model: Aqara Opple 2-gang
+ #**YAR** - TBConfirmed            manufacturer: Xiaomi
+ #**YAR** - TBConfirmed            model: Aqara Opple 2-gang
           - integration: deconz
-#**YAR** - TBConfirmed            manufacturer: Xiaomi
-#**YAR** - TBConfirmed            model: Aqara Opple 2-gang
+ #**YAR** - TBConfirmed            manufacturer: Xiaomi
+ #**YAR** - TBConfirmed            model: Aqara Opple 2-gang
           multiple: false
 #      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -247,12 +247,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -261,7 +261,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -313,7 +313,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: button_2_triple
-#**YAR** - ADD END
+ #**YAR** - ADD END
   - platform: event
     event_type:
       - deconz_event
@@ -324,8 +324,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
-#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -341,10 +341,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -354,8 +354,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
-#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -366,7 +366,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - Xiaomi WXCJKG11LM Aqara Opple 2 button remote
 
     Controller automation for executing any kind of action triggered by the provided Xiaomi WXCJKG11LM Aqara Opple 2 button remote. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -15,8 +15,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025.01.02
-  source_url: https://github.com/lsismeiro/ro/ro/ro/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
+    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
   domain: automation
   input:
     integration:
@@ -28,13 +29,36 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
+          filter:
+#**YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG11LM.html#aqara-wxcjkg11lm
+          - integration: mqtt
+            manufacturer: Aqara
+            model: Opple wireless switch (single band)
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: Aqara
+            model: Opple wireless switch (single band) (WXCJKG11LM)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          - integration: zha
+#**YAR** - TBConfirmed            manufacturer: Xiaomi
+#**YAR** - TBConfirmed            model: Aqara Opple 2-gang
+          - integration: deconz
+#**YAR** - TBConfirmed            manufacturer: Xiaomi
+#**YAR** - TBConfirmed            model: Aqara Opple 2-gang
+          multiple: false
+#      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+#      default: ''
+#      selector:
+#        device:
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -208,17 +232,6 @@ variables:
       button_2_release: [button_2_release]
       button_2_double: [button_2_double]
       button_2_triple: [button_2_triple]
-    zigbee2mqtt_v2:
-      button_1_short: [button_1_single]
-      button_1_long: [button_1_hold]
-      button_1_release: [button_1_release]
-      button_1_double: [button_1_double]
-      button_1_triple: [button_1_triple]
-      button_2_short: [button_2_single]
-      button_2_long: [button_2_hold]
-      button_2_release: [button_2_release]
-      button_2_double: [button_2_double]
-      button_2_triple: [button_2_triple]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_1_short: '{{ actions_mapping[integration_id]["button_1_short"] }}'
@@ -234,16 +247,22 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -294,7 +313,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: button_2_triple
-  # trigger for other integrations
+#**YAR** - ADD END
   - platform: event
     event_type:
       - deconz_event
@@ -305,12 +324,14 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
+#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -318,11 +339,12 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
-
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -332,16 +354,19 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
+#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - Xiaomi WXCJKG11LM Aqara Opple 2 button remote
 
     Controller automation for executing any kind of action triggered by the provided Xiaomi WXCJKG11LM Aqara Opple 2 button remote. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025.01.02
   source_url: https://github.com/lsismeiro/ro/ro/ro/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
   domain: automation
   input:
@@ -28,8 +28,9 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
       default: ''
       selector:
@@ -207,6 +208,17 @@ variables:
       button_2_release: [button_2_release]
       button_2_double: [button_2_double]
       button_2_triple: [button_2_triple]
+    zigbee2mqtt_v2:
+      button_1_short: [button_1_single]
+      button_1_long: [button_1_hold]
+      button_1_release: [button_1_release]
+      button_1_double: [button_1_double]
+      button_1_triple: [button_1_triple]
+      button_2_short: [button_2_single]
+      button_2_long: [button_2_hold]
+      button_2_release: [button_2_release]
+      button_2_double: [button_2_double]
+      button_2_triple: [button_2_triple]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_1_short: '{{ actions_mapping[integration_id]["button_1_short"] }}'
@@ -231,6 +243,57 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_single
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_double
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_triple
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_single
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_double
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_triple
   # trigger for other integrations
   - platform: event
     event_type:
@@ -246,6 +309,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -256,6 +321,8 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -268,6 +335,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
@@ -30,35 +30,30 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
-# **YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG11LM.html#aqara-wxcjkg11lm
+          # **YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG11LM.html#aqara-wxcjkg11lm
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (single band)
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (single band) (WXCJKG11LM)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
-# **YAR** - TBConfirmed            manufacturer: Xiaomi
-# **YAR** - TBConfirmed            model: Aqara Opple 2-gang
+          # **YAR** - TBConfirmed manufacturer: Xiaomi
+          # **YAR** - TBConfirmed  model: Aqara Opple 2-gang
           - integration: deconz
-# **YAR** - TBConfirmed            manufacturer: Xiaomi
-# **YAR** - TBConfirmed            model: Aqara Opple 2-gang
+          # **YAR** - TBConfirmed manufacturer: Xiaomi
+          # **YAR** - TBConfirmed model: Aqara Opple 2-gang
           multiple: false
-#      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
-#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
-#      default: ''
-#      selector:
-#        device:
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -247,12 +242,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -261,7 +256,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -313,7 +308,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: button_2_triple
-# **YAR** - ADD END
+  # **YAR** - ADD END
   - platform: event
     event_type:
       - deconz_event
@@ -324,8 +319,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
-# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -341,10 +336,8 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -354,8 +347,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
-# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -366,7 +359,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
@@ -30,14 +30,14 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
- #**YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG11LM.html#aqara-wxcjkg11lm
+# **YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG11LM.html#aqara-wxcjkg11lm
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (single band)
@@ -45,20 +45,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (single band) (WXCJKG11LM)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
- #**YAR** - TBConfirmed            manufacturer: Xiaomi
- #**YAR** - TBConfirmed            model: Aqara Opple 2-gang
+# **YAR** - TBConfirmed            manufacturer: Xiaomi
+# **YAR** - TBConfirmed            model: Aqara Opple 2-gang
           - integration: deconz
- #**YAR** - TBConfirmed            manufacturer: Xiaomi
- #**YAR** - TBConfirmed            model: Aqara Opple 2-gang
+# **YAR** - TBConfirmed            manufacturer: Xiaomi
+# **YAR** - TBConfirmed            model: Aqara Opple 2-gang
           multiple: false
 #      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -247,12 +247,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -261,7 +261,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -313,7 +313,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: button_2_triple
- #**YAR** - ADD END
+# **YAR** - ADD END
   - platform: event
     event_type:
       - deconz_event
@@ -324,8 +324,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
- #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -341,10 +341,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -354,8 +354,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
- #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -366,7 +366,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - Xiaomi WXCJKG12LM Aqara Opple 4 button remote
 
     Controller automation for executing any kind of action triggered by the provided Xiaomi WXCJKG12LM Aqara Opple 4 button remote. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -28,8 +28,9 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
       default: ''
       selector:
@@ -337,6 +338,27 @@ variables:
       button_4_release: [button_4_release]
       button_4_double: [button_4_double]
       button_4_triple: [button_4_triple]
+    zigbee2mqtt_v2:
+      button_1_short: [button_1_single]
+      button_1_long: [button_1_hold]
+      button_1_release: [button_1_release]
+      button_1_double: [button_1_double]
+      button_1_triple: [button_1_triple]
+      button_2_short: [button_2_single]
+      button_2_long: [button_2_hold]
+      button_2_release: [button_2_release]
+      button_2_double: [button_2_double]
+      button_2_triple: [button_2_triple]
+      button_3_short: [button_3_single]
+      button_3_long: [button_3_hold]
+      button_3_release: [button_3_release]
+      button_3_double: [button_3_double]
+      button_3_triple: [button_3_triple]
+      button_4_short: [button_4_single]
+      button_4_long: [button_4_hold]
+      button_4_release: [button_4_release]
+      button_4_double: [button_4_double]
+      button_4_triple: [button_4_triple]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_1_short: '{{ actions_mapping[integration_id]["button_1_short"] }}'
@@ -371,6 +393,107 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_1_single
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_1_hold
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_1_release
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_1_double
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_1_triple
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_2_single
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_2_hold
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_2_release
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_2_double
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_2_triple
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_3_single
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_3_hold
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_3_release
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_3_double
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_3_triple
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_4_single
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_4_hold
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_4_release
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_4_double
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_4_triple
   # trigger for other integrations
   - platform: event
     event_type:
@@ -386,6 +509,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -396,6 +521,8 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -408,6 +535,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
@@ -395,105 +395,105 @@ trigger:
       entity_id: !input controller_entity
   # triggers for zigbee2mqtt_v2
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_1_single
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_single
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_1_hold
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_hold
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_1_release
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_release
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_1_double
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_double
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_1_triple
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_triple
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_2_single
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_single
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_2_hold
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_hold
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_2_release
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_release
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_2_double
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_double
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_2_triple
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_triple
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_3_single
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_single
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_3_hold
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_hold
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_3_release
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_release
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_3_double
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_double
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_3_triple
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_triple
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_4_single
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_single
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_4_hold
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_hold
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_4_release
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_release
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_4_double
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_double
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_4_triple
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_triple
   # trigger for other integrations
   - platform: event
     event_type:

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
@@ -30,14 +30,14 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
- #**YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG12LM.html#aqara-wxcjkg12lm
+# **YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG12LM.html#aqara-wxcjkg12lm
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (double band)
@@ -45,20 +45,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (double band) (WXCJKG12LM)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
- #**YAR** - TBConfirmed            manufacturer: Xiaomi
- #**YAR** - TBConfirmed            model: Aqara Opple 4-gang
+# **YAR** - TBConfirmed            manufacturer: Xiaomi
+# **YAR** - TBConfirmed            model: Aqara Opple 4-gang
           - integration: deconz
- #**YAR** - TBConfirmed            manufacturer: Xiaomi
- #**YAR** - TBConfirmed            model: Aqara Opple 4-gang
+# **YAR** - TBConfirmed            manufacturer: Xiaomi
+# **YAR** - TBConfirmed            model: Aqara Opple 4-gang
           multiple: false
 #      name: (deCONZ, ZHA) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -387,9 +387,9 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
 mode: restart
@@ -400,7 +400,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -502,7 +502,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: button_4_triple
- #**YAR** - ADD END
+# **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -514,8 +514,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
- #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -531,10 +531,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -544,8 +544,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
- #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -556,7 +556,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
@@ -30,35 +30,30 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
-# **YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG12LM.html#aqara-wxcjkg12lm
+          # **YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG12LM.html#aqara-wxcjkg12lm
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (double band)
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (double band) (WXCJKG12LM)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
-# **YAR** - TBConfirmed            manufacturer: Xiaomi
-# **YAR** - TBConfirmed            model: Aqara Opple 4-gang
+          # **YAR** - TBConfirmed manufacturer: Xiaomi
+          # **YAR** - TBConfirmed  model: Aqara Opple 4-gang
           - integration: deconz
-# **YAR** - TBConfirmed            manufacturer: Xiaomi
-# **YAR** - TBConfirmed            model: Aqara Opple 4-gang
+          # **YAR** - TBConfirmed manufacturer: Xiaomi
+          # **YAR** - TBConfirmed model: Aqara Opple 4-gang
           multiple: false
-#      name: (deCONZ, ZHA) Controller Device
-#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
-#      default: ''
-#      selector:
-#        device:
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -387,11 +382,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  # **YAR** - ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -400,7 +396,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -502,7 +498,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: button_4_triple
-# **YAR** - ADD END
+  # **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -514,8 +510,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
-# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -531,10 +527,8 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -544,8 +538,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
-# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -556,7 +550,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
@@ -30,14 +30,14 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
           filter:
-#**YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG12LM.html#aqara-wxcjkg12lm
+ #**YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG12LM.html#aqara-wxcjkg12lm
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (double band)
@@ -45,20 +45,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (double band) (WXCJKG12LM)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
-#**YAR** - TBConfirmed            manufacturer: Xiaomi
-#**YAR** - TBConfirmed            model: Aqara Opple 4-gang
+ #**YAR** - TBConfirmed            manufacturer: Xiaomi
+ #**YAR** - TBConfirmed            model: Aqara Opple 4-gang
           - integration: deconz
-#**YAR** - TBConfirmed            manufacturer: Xiaomi
-#**YAR** - TBConfirmed            model: Aqara Opple 4-gang
+ #**YAR** - TBConfirmed            manufacturer: Xiaomi
+ #**YAR** - TBConfirmed            model: Aqara Opple 4-gang
           multiple: false
 #      name: (deCONZ, ZHA) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -387,9 +387,9 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
 mode: restart
@@ -400,7 +400,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -502,7 +502,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: button_4_triple
-#**YAR** - ADD END
+ #**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -514,8 +514,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
-#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -531,10 +531,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -544,8 +544,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
-#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -556,7 +556,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - Xiaomi WXCJKG12LM Aqara Opple 4 button remote
 
     Controller automation for executing any kind of action triggered by the provided Xiaomi WXCJKG12LM Aqara Opple 4 button remote. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -16,7 +16,8 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2022.08.08
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
   domain: automation
   input:
     integration:
@@ -28,13 +29,36 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
+          filter:
+#**YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG12LM.html#aqara-wxcjkg12lm
+          - integration: mqtt
+            manufacturer: Aqara
+            model: Opple wireless switch (double band)
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: Aqara
+            model: Opple wireless switch (double band) (WXCJKG12LM)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          - integration: zha
+#**YAR** - TBConfirmed            manufacturer: Xiaomi
+#**YAR** - TBConfirmed            model: Aqara Opple 4-gang
+          - integration: deconz
+#**YAR** - TBConfirmed            manufacturer: Xiaomi
+#**YAR** - TBConfirmed            model: Aqara Opple 4-gang
+          multiple: false
+#      name: (deCONZ, ZHA) Controller Device
+#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+#      default: ''
+#      selector:
+#        device:
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -338,27 +362,6 @@ variables:
       button_4_release: [button_4_release]
       button_4_double: [button_4_double]
       button_4_triple: [button_4_triple]
-    zigbee2mqtt_v2:
-      button_1_short: [button_1_single]
-      button_1_long: [button_1_hold]
-      button_1_release: [button_1_release]
-      button_1_double: [button_1_double]
-      button_1_triple: [button_1_triple]
-      button_2_short: [button_2_single]
-      button_2_long: [button_2_hold]
-      button_2_release: [button_2_release]
-      button_2_double: [button_2_double]
-      button_2_triple: [button_2_triple]
-      button_3_short: [button_3_single]
-      button_3_long: [button_3_hold]
-      button_3_release: [button_3_release]
-      button_3_double: [button_3_double]
-      button_3_triple: [button_3_triple]
-      button_4_short: [button_4_single]
-      button_4_long: [button_4_hold]
-      button_4_release: [button_4_release]
-      button_4_double: [button_4_double]
-      button_4_triple: [button_4_triple]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_1_short: '{{ actions_mapping[integration_id]["button_1_short"] }}'
@@ -384,16 +387,21 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -494,6 +502,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: button_4_triple
+#**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -505,12 +514,14 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
+#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -518,11 +529,12 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
-
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -532,16 +544,19 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
+#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - Xiaomi WXCJKG13LM Aqara Opple 6 button remote
 
     Controller automation for executing any kind of action triggered by the provided Xiaomi WXCJKG13LM Aqara Opple 6 button remote. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025.01.03
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
   domain: automation
   input:
@@ -28,8 +28,9 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
       default: ''
       selector:
@@ -467,6 +468,37 @@ variables:
       button_6_release: [button_6_release]
       button_6_double: [button_6_double]
       button_6_triple: [button_6_triple]
+    zigbee2mqtt_v2:
+      button_1_short: [button_1_single]
+      button_1_long: [button_1_hold]
+      button_1_release: [button_1_release]
+      button_1_double: [button_1_double]
+      button_1_triple: [button_1_triple]
+      button_2_short: [button_2_single]
+      button_2_long: [button_2_hold]
+      button_2_release: [button_2_release]
+      button_2_double: [button_2_double]
+      button_2_triple: [button_2_triple]
+      button_3_short: [button_3_single]
+      button_3_long: [button_3_hold]
+      button_3_release: [button_3_release]
+      button_3_double: [button_3_double]
+      button_3_triple: [button_3_triple]
+      button_4_short: [button_4_single]
+      button_4_long: [button_4_hold]
+      button_4_release: [button_4_release]
+      button_4_double: [button_4_double]
+      button_4_triple: [button_4_triple]
+      button_5_short: [button_5_single]
+      button_5_long: [button_5_hold]
+      button_5_release: [button_5_release]
+      button_5_double: [button_5_double]
+      button_5_triple: [button_5_triple]
+      button_6_short: [button_6_single]
+      button_6_long: [button_6_hold]
+      button_6_release: [button_6_release]
+      button_6_double: [button_6_double]
+      button_6_triple: [button_6_triple]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_1_short: '{{ actions_mapping[integration_id]["button_1_short"] }}'
@@ -511,6 +543,82 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_1_hold
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_1_double
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_2_single
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_2_release
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_2_triple
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_3_hold
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_3_double
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_4_single
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_4_release
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_4_triple
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_5_hold
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_5_double
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_6_single
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_6_release
+  - platform: device
+        domain: mqtt
+        device_id: !input controller_device
+        type: action
+        subtype: button_6_triple
   # trigger for other integrations
   - platform: event
     event_type:
@@ -526,6 +634,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -536,6 +646,8 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -548,6 +660,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
@@ -30,13 +30,13 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-#**YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG13LM.html#aqara-wxcjkg13lm
+ #**YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG13LM.html#aqara-wxcjkg13lm
           filter:
           - integration: mqtt
             manufacturer: Aqara
@@ -45,20 +45,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (triple band) (WXCJKG13LM)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
-#**YAR** - TBConfirmed            manufacturer: Xiaomi
-#**YAR** - TBConfirmed            model: Aqara Opple 6-gang
+ #**YAR** - TBConfirmed            manufacturer: Xiaomi
+ #**YAR** - TBConfirmed            model: Aqara Opple 6-gang
           - integration: deconz
-#**YAR** - TBConfirmed            manufacturer: Xiaomi
-#**YAR** - TBConfirmed            model: Aqara Opple 6-gang
+ #**YAR** - TBConfirmed            manufacturer: Xiaomi
+ #**YAR** - TBConfirmed            model: Aqara Opple 6-gang
           multiple: false
 #      name: (deCONZ, ZHA) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -527,12 +527,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -541,7 +541,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   #button_1
   - platform: device
@@ -699,7 +699,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: button_6_triple
-#**YAR** - ADD END
+ #**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -711,8 +711,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
-#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -728,10 +728,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -741,8 +741,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
-#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -753,7 +753,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - Xiaomi WXCJKG13LM Aqara Opple 6 button remote
 
     Controller automation for executing any kind of action triggered by the provided Xiaomi WXCJKG13LM Aqara Opple 6 button remote. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -15,8 +15,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025.01.03
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
   domain: automation
   input:
     integration:
@@ -28,13 +29,36 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
+#**YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG13LM.html#aqara-wxcjkg13lm
+          filter:
+          - integration: mqtt
+            manufacturer: Aqara
+            model: Opple wireless switch (triple band)
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: Aqara
+            model: Opple wireless switch (triple band) (WXCJKG13LM)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          - integration: zha
+#**YAR** - TBConfirmed            manufacturer: Xiaomi
+#**YAR** - TBConfirmed            model: Aqara Opple 6-gang
+          - integration: deconz
+#**YAR** - TBConfirmed            manufacturer: Xiaomi
+#**YAR** - TBConfirmed            model: Aqara Opple 6-gang
+          multiple: false
+#      name: (deCONZ, ZHA) Controller Device
+#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+#      default: ''
+#      selector:
+#        device:
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -468,37 +492,6 @@ variables:
       button_6_release: [button_6_release]
       button_6_double: [button_6_double]
       button_6_triple: [button_6_triple]
-    zigbee2mqtt_v2:
-      button_1_short: [button_1_single]
-      button_1_long: [button_1_hold]
-      button_1_release: [button_1_release]
-      button_1_double: [button_1_double]
-      button_1_triple: [button_1_triple]
-      button_2_short: [button_2_single]
-      button_2_long: [button_2_hold]
-      button_2_release: [button_2_release]
-      button_2_double: [button_2_double]
-      button_2_triple: [button_2_triple]
-      button_3_short: [button_3_single]
-      button_3_long: [button_3_hold]
-      button_3_release: [button_3_release]
-      button_3_double: [button_3_double]
-      button_3_triple: [button_3_triple]
-      button_4_short: [button_4_single]
-      button_4_long: [button_4_hold]
-      button_4_release: [button_4_release]
-      button_4_double: [button_4_double]
-      button_4_triple: [button_4_triple]
-      button_5_short: [button_5_single]
-      button_5_long: [button_5_hold]
-      button_5_release: [button_5_release]
-      button_5_double: [button_5_double]
-      button_5_triple: [button_5_triple]
-      button_6_short: [button_6_single]
-      button_6_long: [button_6_hold]
-      button_6_release: [button_6_release]
-      button_6_double: [button_6_double]
-      button_6_triple: [button_6_triple]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_1_short: '{{ actions_mapping[integration_id]["button_1_short"] }}'
@@ -534,16 +527,28 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
+  #button_1
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_single
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -553,7 +558,18 @@ trigger:
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: button_1_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: button_1_double
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_triple
+  #button_2
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -563,12 +579,28 @@ trigger:
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: button_2_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: button_2_release
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: button_2_double
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: button_2_triple
+  #button_3
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_single
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -578,7 +610,18 @@ trigger:
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: button_3_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: button_3_double
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_triple
+  #button_4
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -588,12 +631,28 @@ trigger:
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: button_4_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: button_4_release
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: button_4_double
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: button_4_triple
+  #button_5
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_5_single
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -603,7 +662,18 @@ trigger:
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: button_5_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: button_5_double
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_5_triple
+  #button_6
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -613,12 +683,23 @@ trigger:
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: button_6_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: button_6_release
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: button_6_double
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: button_6_triple
+#**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -630,12 +711,14 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
+#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -643,11 +726,12 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
-
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -657,16 +741,19 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
+#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
@@ -30,13 +30,13 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
- #**YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG13LM.html#aqara-wxcjkg13lm
+# **YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG13LM.html#aqara-wxcjkg13lm
           filter:
           - integration: mqtt
             manufacturer: Aqara
@@ -45,20 +45,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (triple band) (WXCJKG13LM)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
- #**YAR** - TBConfirmed            manufacturer: Xiaomi
- #**YAR** - TBConfirmed            model: Aqara Opple 6-gang
+# **YAR** - TBConfirmed            manufacturer: Xiaomi
+# **YAR** - TBConfirmed            model: Aqara Opple 6-gang
           - integration: deconz
- #**YAR** - TBConfirmed            manufacturer: Xiaomi
- #**YAR** - TBConfirmed            model: Aqara Opple 6-gang
+# **YAR** - TBConfirmed            manufacturer: Xiaomi
+# **YAR** - TBConfirmed            model: Aqara Opple 6-gang
           multiple: false
 #      name: (deCONZ, ZHA) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -527,12 +527,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -541,7 +541,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   #button_1
   - platform: device
@@ -699,7 +699,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: button_6_triple
- #**YAR** - ADD END
+# **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -711,8 +711,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
- #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -728,10 +728,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -741,8 +741,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
- #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -753,7 +753,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
@@ -545,80 +545,80 @@ trigger:
       entity_id: !input controller_entity
   # triggers for zigbee2mqtt_v2
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_1_hold
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_hold
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_1_double
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_double
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_2_single
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_single
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_2_release
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_release
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_2_triple
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_triple
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_3_hold
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_hold
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_3_double
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_double
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_4_single
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_single
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_4_release
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_release
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_4_triple
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_triple
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_5_hold
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_5_hold
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_5_double
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_5_double
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_6_single
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_6_single
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_6_release
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_6_release
   - platform: device
-        domain: mqtt
-        device_id: !input controller_device
-        type: action
-        subtype: button_6_triple
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_6_triple
   # trigger for other integrations
   - platform: event
     event_type:

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
@@ -30,35 +30,30 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-# **YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG13LM.html#aqara-wxcjkg13lm
+          # **YAR** - https://www.zigbee2mqtt.io/devices/WXCJKG13LM.html#aqara-wxcjkg13lm
           filter:
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (triple band)
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: Aqara
             model: Opple wireless switch (triple band) (WXCJKG13LM)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
-# **YAR** - TBConfirmed            manufacturer: Xiaomi
-# **YAR** - TBConfirmed            model: Aqara Opple 6-gang
+          # **YAR** - TBConfirmed manufacturer: Xiaomi
+          # **YAR** - TBConfirmed model: Aqara Opple 6-gang
           - integration: deconz
-# **YAR** - TBConfirmed            manufacturer: Xiaomi
-# **YAR** - TBConfirmed            model: Aqara Opple 6-gang
+          # **YAR** - TBConfirmed manufacturer: Xiaomi
+          # **YAR** - TBConfirmed model: Aqara Opple 6-gang
           multiple: false
-#      name: (deCONZ, ZHA) Controller Device
-#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
-#      default: ''
-#      selector:
-#        device:
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -527,12 +522,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -541,7 +536,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   #button_1
   - platform: device
@@ -699,7 +694,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: button_6_triple
-# **YAR** - ADD END
+  # **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -711,8 +706,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
-# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -728,10 +723,8 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -741,8 +734,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
-# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -753,7 +746,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - Xiaomi WXKG11LM Aqara Wireless Switch Mini
 
     Controller automation for executing any kind of action triggered by the provided Xiaomi WXKG11LM Aqara Wireless Switch Mini. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
+    Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -15,8 +15,9 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025.01.03
-  source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
+    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025.01.07 - Added support for z2m 2.x mqtt device triggers - yarafie
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
   domain: automation
   input:
     integration:
@@ -28,13 +29,36 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
-            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2
+#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
+#**YAR** - https://www.zigbee2mqtt.io/devices/WXKG01LM.html#xiaomi-wxkg01lm
+          filter:
+          - integration: mqtt
+            manufacturer: Xiaomi
+            model: Mi wireless switch
+          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          - integration: mqtt
+            manufacturer: Xiaomi
+            model: Mi wireless switch (WXKG01LM)
+#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          - integration: zha
+#**YAR** - TBConfirmed            manufacturer: Xiaomi
+#**YAR** - TBConfirmed            model: Mi round smart wireless switch
+          - integration: deconz
+#**YAR** - TBConfirmed            manufacturer: Xiaomi
+#**YAR** - TBConfirmed            model: Mi round smart wireless switch
+          multiple: false
+#      name: (deCONZ, ZHA) Controller Device
+#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+#      default: ''
+#      selector:
+#        device:
+#**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -134,11 +158,6 @@ variables:
       button_long: [hold]
       button_release: [release]
       button_double: [double]
-    zigbee2mqtt_v2:
-      button_short: [single]
-      button_long: [hold]
-      button_release: [release]
-      button_double: [double]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_short: '{{ actions_mapping[integration_id]["button_short"] }}'
@@ -148,16 +167,22 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD - Logic to handle z2m legacy
+#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
+  controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+#**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for zigbee2mqtt entity sensor action events (legacy)
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-  # triggers for zigbee2mqtt_v2
+#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -178,6 +203,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: double
+#**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -189,23 +215,27 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
+#**YAR** - ADD zigbee2mqtt checks for device or entity
+#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
-        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+        {{ trigger.event.data.command }}
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+      # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
+#**YAR** - Below needed to change if z2m entity or device not sure I got this right
+#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+#**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -215,16 +245,19 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
+#**YAR** - ADD zigbee2mqtt actions for device or entity
+#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}
       trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
+        {%- elif integration_id == "zigbee2mqtt" and z2m_legacy == true -%}
+        {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
+#**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - Xiaomi WXKG11LM Aqara Wireless Switch Mini
 
     Controller automation for executing any kind of action triggered by the provided Xiaomi WXKG11LM Aqara Wireless Switch Mini. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT, and Zigbee2MQTT_V2 with legacy=false.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.08.08
+    ℹ️ Version 2025.01.03
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
   domain: automation
   input:
@@ -28,9 +28,10 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - Zigbee2MQTT_V2
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT_V2) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT_V2
       default: ''
       selector:
         device:
@@ -133,6 +134,11 @@ variables:
       button_long: [hold]
       button_release: [release]
       button_double: [double]
+    zigbee2mqtt_v2:
+      button_short: [single]
+      button_long: [hold]
+      button_release: [release]
+      button_double: [double]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_short: '{{ actions_mapping[integration_id]["button_short"] }}'
@@ -151,6 +157,27 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt_v2
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: single
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: double
   # trigger for other integrations
   - platform: event
     event_type:
@@ -166,6 +193,8 @@ condition:
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -176,6 +205,7 @@ condition:
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt_v2" or trigger.payload != last_controller_event }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -188,6 +218,8 @@ action:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "zigbee2mqtt_v2" -%}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
@@ -30,13 +30,13 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
- #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
- #**YAR** - https://www.zigbee2mqtt.io/devices/WXKG01LM.html#xiaomi-wxkg01lm
+# **YAR** - https://www.zigbee2mqtt.io/devices/WXKG01LM.html#xiaomi-wxkg01lm
           filter:
           - integration: mqtt
             manufacturer: Xiaomi
@@ -45,20 +45,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Xiaomi
             model: Mi wireless switch (WXKG01LM)
- #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
- #**YAR** - TBConfirmed            manufacturer: Xiaomi
- #**YAR** - TBConfirmed            model: Mi round smart wireless switch
+# **YAR** - TBConfirmed            manufacturer: Xiaomi
+# **YAR** - TBConfirmed            model: Mi round smart wireless switch
           - integration: deconz
- #**YAR** - TBConfirmed            manufacturer: Xiaomi
- #**YAR** - TBConfirmed            model: Mi round smart wireless switch
+# **YAR** - TBConfirmed            manufacturer: Xiaomi
+# **YAR** - TBConfirmed            model: Mi round smart wireless switch
           multiple: false
 #      name: (deCONZ, ZHA) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
- #**YAR** - ADD END
+# **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -167,12 +167,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
- #**YAR** ADD - Logic to handle z2m legacy
- #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
- #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+# **YAR** ADD - Logic to handle z2m legacy
+# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
- #**YAR** ADD END
+# **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -181,7 +181,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
- #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -203,7 +203,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: double
- #**YAR** - ADD END
+# **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -215,8 +215,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
- #**YAR** - ADD zigbee2mqtt checks for device or entity
- #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+# **YAR** - ADD zigbee2mqtt checks for device or entity
+# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -232,10 +232,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
- #**YAR** - Below needed to change if z2m entity or device not sure I got this right
- #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+# **YAR** - Below needed to change if z2m entity or device not sure I got this right
+# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
- #**YAR** - ADD END
+# **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -245,8 +245,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
- #**YAR** - ADD zigbee2mqtt actions for device or entity
- #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}
+# **YAR** - ADD zigbee2mqtt actions for device or entity
+# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -257,7 +257,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
- #**YAR** - ADD END
+# **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
@@ -30,35 +30,30 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-# **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+      # **YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-# **YAR** - https://www.zigbee2mqtt.io/devices/WXKG01LM.html#xiaomi-wxkg01lm
+          # **YAR** - https://www.zigbee2mqtt.io/devices/WXKG01LM.html#xiaomi-wxkg01lm
           filter:
           - integration: mqtt
             manufacturer: Xiaomi
             model: Mi wireless switch
-          #**For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+          # **For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
           - integration: mqtt
             manufacturer: Xiaomi
             model: Mi wireless switch (WXKG01LM)
-# **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+          # **YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
-# **YAR** - TBConfirmed            manufacturer: Xiaomi
-# **YAR** - TBConfirmed            model: Mi round smart wireless switch
+          # **YAR** - TBConfirmed manufacturer: Xiaomi
+          # **YAR** - TBConfirmed  model: Mi round smart wireless switch
           - integration: deconz
-# **YAR** - TBConfirmed            manufacturer: Xiaomi
-# **YAR** - TBConfirmed            model: Mi round smart wireless switch
+          # **YAR** - TBConfirmed manufacturer: Xiaomi
+          # **YAR** - TBConfirmed model: Mi round smart wireless switch
           multiple: false
-#      name: (deCONZ, ZHA) Controller Device
-#      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
-#      default: ''
-#      selector:
-#        device:
-# **YAR** - ADD END
+      # **YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -167,12 +162,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-# **YAR** ADD - Logic to handle z2m legacy
-# **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-# **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+  # **YAR** ADD - Logic to handle z2m legacy
+  # **YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+  # **YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-# **YAR** ADD END
+  # **YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -181,7 +176,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-# **YAR** - ADD - zigbee2mqtt mqtt device action triggers
+  # **YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -203,7 +198,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: double
-# **YAR** - ADD END
+  # **YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -215,8 +210,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-# **YAR** - ADD zigbee2mqtt checks for device or entity
-# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+      # **YAR** - ADD zigbee2mqtt checks for device or entity
+      # **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -232,10 +227,8 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-# **YAR** - Below needed to change if z2m entity or device not sure I got this right
-# **YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-# **YAR** - ADD END
+      # **YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -245,8 +238,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-# **YAR** - ADD zigbee2mqtt actions for device or entity
-# **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}
+      # **YAR** - ADD zigbee2mqtt actions for device or entity
+      # **YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -257,7 +250,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-# **YAR** - ADD END
+      # **YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
@@ -30,13 +30,13 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-#**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
+ #**YAR** - ADD - To Support zigbee2mqtt mqtt device triggers when legacy=false
       name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-#**YAR** - https://www.zigbee2mqtt.io/devices/WXKG01LM.html#xiaomi-wxkg01lm
+ #**YAR** - https://www.zigbee2mqtt.io/devices/WXKG01LM.html#xiaomi-wxkg01lm
           filter:
           - integration: mqtt
             manufacturer: Xiaomi
@@ -45,20 +45,20 @@ blueprint:
           - integration: mqtt
             manufacturer: Xiaomi
             model: Mi wireless switch (WXKG01LM)
-#**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+ #**YAR** - https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
           - integration: zha
-#**YAR** - TBConfirmed            manufacturer: Xiaomi
-#**YAR** - TBConfirmed            model: Mi round smart wireless switch
+ #**YAR** - TBConfirmed            manufacturer: Xiaomi
+ #**YAR** - TBConfirmed            model: Mi round smart wireless switch
           - integration: deconz
-#**YAR** - TBConfirmed            manufacturer: Xiaomi
-#**YAR** - TBConfirmed            model: Mi round smart wireless switch
+ #**YAR** - TBConfirmed            manufacturer: Xiaomi
+ #**YAR** - TBConfirmed            model: Mi round smart wireless switch
           multiple: false
 #      name: (deCONZ, ZHA) Controller Device
 #      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
 #      default: ''
 #      selector:
 #        device:
-#**YAR** - ADD END
+ #**YAR** - ADD END
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
       description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
@@ -167,12 +167,12 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-#**YAR** ADD - Logic to handle z2m legacy
-#**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
-#**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
+ #**YAR** ADD - Logic to handle z2m legacy
+ #**YAR** If user provided input for controller_entity assume legacy **Maybe There Is A Better Way To Do This**
+ #**YAR** setting z2m_legacy to true with below code and set controller_id accordingly
   z2m_legacy: '{{ integration_id == "zigbee2mqtt" and controller_entity not in ["", None, undefined] }}'
   controller_id: '{% if z2m_legacy %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
-#**YAR** ADD END
+ #**YAR** ADD END
 mode: restart
 max_exceeded: silent
 trigger:
@@ -181,7 +181,7 @@ trigger:
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
-#**YAR** - ADD - zigbee2mqtt mqtt device action triggers
+ #**YAR** - ADD - zigbee2mqtt mqtt device action triggers
   # triggers for zigbee2mqtt mqtt device action
   - platform: device
     domain: mqtt
@@ -203,7 +203,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: double
-#**YAR** - ADD END
+ #**YAR** - ADD END
   # trigger for other integrations
   - platform: event
     event_type:
@@ -215,8 +215,8 @@ condition:
   - condition: and
     conditions:
       # check that the button event is not empty
-#**YAR** - ADD zigbee2mqtt checks for device or entity
-#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+ #**YAR** - ADD zigbee2mqtt checks for device or entity
+ #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
@@ -232,10 +232,10 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt in legacy mode, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-#**YAR** - Below needed to change if z2m entity or device not sure I got this right
-#**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+ #**YAR** - Below needed to change if z2m entity or device not sure I got this right
+ #**YAR**      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
       - '{{ not (integration_id == "zigbee2mqtt" and z2m_legacy) or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-#**YAR** - ADD END
+ #**YAR** - ADD END
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -245,8 +245,8 @@ action:
   # extract button event from the trigger
   # provide a single string value to check against
   - variables:
-#**YAR** - ADD zigbee2mqtt actions for device or entity
-#**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}
+ #**YAR** - ADD zigbee2mqtt actions for device or entity
+ #**YAR** NEED TO CHECK FOR ZHA        {{ trigger.event.data.command }}
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" and z2m_legacy == false -%}
         {{ trigger.payload }}
@@ -257,7 +257,7 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-#**YAR** - ADD END
+ #**YAR** - ADD END
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value

--- a/blueprints/hooks/cover/cover.yaml
+++ b/blueprints/hooks/cover/cover.yaml
@@ -17,7 +17,7 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2022.07.30
-    ℹ️ Version 2025.01.07 - Added support for IKEA RODRET E2202 - yarafie
+    ℹ️ Version 2025.01.07 - Added support for IKEA RODRET (E2201) yarafie
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/hooks/cover/cover.yaml
   domain: automation
   input:

--- a/blueprints/hooks/cover/cover.yaml
+++ b/blueprints/hooks/cover/cover.yaml
@@ -42,9 +42,9 @@ blueprint:
           options:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
- #**YAR** - ADD - IKEA RODRET
+# **YAR** - ADD - IKEA RODRET
             - IKEA E2201 RODRET Dimmer
- #**YAR** - ADD - END
+# **YAR** - ADD - END
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1812 TRÅDFRI Shortcut button
             - SONOFF SNZB-01 Wireless Switch
@@ -79,14 +79,14 @@ variables:
       close_cover: button_down_short
       close_cover_tilt: button_down_long
       stop_cover_all: button_down_double
- #**YAR** - ADD - IKEA RODRET
+# **YAR** - ADD - IKEA RODRET
     IKEA E2201 RODRET Dimmer:
       open_cover: button_up_short
       open_cover_tilt: button_up_long
       close_cover: button_down_short
       close_cover_tilt: button_down_long
       stop_cover_all: button_down_double
- #**YAR** - ADD END
+# **YAR** - ADD END
     IKEA E1766 TRÅDFRI Open/Close Remote:
       open_cover: button_up_short
       close_cover: button_down_short

--- a/blueprints/hooks/cover/cover.yaml
+++ b/blueprints/hooks/cover/cover.yaml
@@ -33,6 +33,17 @@ blueprint:
       selector:
         entity:
           domain: sensor
+#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    controller_mqtt:
+      name: (Required) Controller MQTT Device
+      description: The controller device which will control the Cover. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as a Device. This value should match the one specified in the corresponding Controller automation.
+      default: ''
+      selector:
+        device:
+          filter:
+          - integration: mqtt
+          multiple: false
+#YAR - ADD END
     controller_model:
       name: (Required) Controller model
       description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
@@ -41,6 +52,9 @@ blueprint:
           options:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+#YAR - ADD - IKEA RODRET
+            - IKEA E2201 RODRET Dimmer
+#YAR - ADD - END
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1812 TRÅDFRI Shortcut button
             - SONOFF SNZB-01 Wireless Switch
@@ -75,6 +89,14 @@ variables:
       close_cover: button_down_short
       close_cover_tilt: button_down_long
       stop_cover_all: button_down_double
+#YAR - ADD - IKEA RODRET
+    IKEA E2201 RODRET Dimmer:
+      open_cover: button_up_short
+      open_cover_tilt: button_up_long
+      close_cover: button_down_short
+      close_cover_tilt: button_down_long
+      stop_cover_all: button_down_double
+#YAR - ADD END
     IKEA E1766 TRÅDFRI Open/Close Remote:
       open_cover: button_up_short
       close_cover: button_down_short
@@ -145,6 +167,12 @@ trigger:
     event_type: ahb_controller_event
     event_data:
       controller: !input controller_entity
+#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  - platform: event
+    event_type: ahb_controller_event
+    event_data:
+      controller: !input controller_mqtt
+#YAR - ADD END
 condition: []
 action:
   - variables:

--- a/blueprints/hooks/cover/cover.yaml
+++ b/blueprints/hooks/cover/cover.yaml
@@ -33,17 +33,6 @@ blueprint:
       selector:
         entity:
           domain: sensor
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-    controller_mqtt:
-      name: (Required) Controller MQTT Device
-      description: The controller device which will control the Cover. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as a Device. This value should match the one specified in the corresponding Controller automation.
-      default: ''
-      selector:
-        device:
-          filter:
-          - integration: mqtt
-          multiple: false
-#YAR - ADD END
     controller_model:
       name: (Required) Controller model
       description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
@@ -167,12 +156,6 @@ trigger:
     event_type: ahb_controller_event
     event_data:
       controller: !input controller_entity
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-  - platform: event
-    event_type: ahb_controller_event
-    event_data:
-      controller: !input controller_mqtt
-#YAR - ADD END
 condition: []
 action:
   - variables:

--- a/blueprints/hooks/cover/cover.yaml
+++ b/blueprints/hooks/cover/cover.yaml
@@ -17,6 +17,7 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2022.07.30
+    ℹ️ Version 2025.01.07 - Added support for IKEA RODRET E2202 - yarafie
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/hooks/cover/cover.yaml
   domain: automation
   input:

--- a/blueprints/hooks/cover/cover.yaml
+++ b/blueprints/hooks/cover/cover.yaml
@@ -42,9 +42,9 @@ blueprint:
           options:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
-# **YAR** - ADD - IKEA RODRET
+            # **YAR** - ADD - IKEA RODRET
             - IKEA E2201 RODRET Dimmer
-# **YAR** - ADD - END
+            # **YAR** - ADD - END
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1812 TRÅDFRI Shortcut button
             - SONOFF SNZB-01 Wireless Switch
@@ -79,14 +79,14 @@ variables:
       close_cover: button_down_short
       close_cover_tilt: button_down_long
       stop_cover_all: button_down_double
-# **YAR** - ADD - IKEA RODRET
+    # **YAR** - ADD - IKEA RODRET
     IKEA E2201 RODRET Dimmer:
       open_cover: button_up_short
       open_cover_tilt: button_up_long
       close_cover: button_down_short
       close_cover_tilt: button_down_long
       stop_cover_all: button_down_double
-# **YAR** - ADD END
+    # **YAR** - ADD END
     IKEA E1766 TRÅDFRI Open/Close Remote:
       open_cover: button_up_short
       close_cover: button_down_short

--- a/blueprints/hooks/cover/cover.yaml
+++ b/blueprints/hooks/cover/cover.yaml
@@ -42,9 +42,9 @@ blueprint:
           options:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
-#YAR - ADD - IKEA RODRET
+ #**YAR** - ADD - IKEA RODRET
             - IKEA E2201 RODRET Dimmer
-#YAR - ADD - END
+ #**YAR** - ADD - END
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1812 TRÅDFRI Shortcut button
             - SONOFF SNZB-01 Wireless Switch
@@ -79,14 +79,14 @@ variables:
       close_cover: button_down_short
       close_cover_tilt: button_down_long
       stop_cover_all: button_down_double
-#YAR - ADD - IKEA RODRET
+ #**YAR** - ADD - IKEA RODRET
     IKEA E2201 RODRET Dimmer:
       open_cover: button_up_short
       open_cover_tilt: button_up_long
       close_cover: button_down_short
       close_cover_tilt: button_down_long
       stop_cover_all: button_down_double
-#YAR - ADD END
+ #**YAR** - ADD END
     IKEA E1766 TRÅDFRI Open/Close Remote:
       open_cover: button_up_short
       close_cover: button_down_short

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -17,7 +17,7 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2022.07.30
-    ℹ️ Version 2025.01.07 - Added support for IKEA RODRET E2202 - yarafie
+    ℹ️ Version 2025.01.07 - Added support for IKEA RODRET (E2201) - yarafie
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/hooks/light/light.yaml
   domain: automation
   input:

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -33,6 +33,17 @@ blueprint:
       selector:
         entity:
           domain: sensor
+#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    controller_mqtt:
+      name: (Required) Controller MQTT Device
+      description: The controller device which will control the Light. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as a Device. This value should match the one specified in the corresponding Controller automation.
+      default: ''
+      selector:
+        device:
+          filter:
+          - integration: mqtt
+          multiple: false
+#YAR - ADD END
     controller_model:
       name: (Required) Controller model
       description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
@@ -42,6 +53,10 @@ blueprint:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer (#2)
+#YAR - ADD - IKEA RODRET
+            - IKEA E2201 RODRET Dimmer
+            - IKEA E2201 RODRET Dimmer (#2)
+#YAR - ADD - END
             - IKEA E1744 SYMFONISK Rotary Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote (#2)
@@ -221,6 +236,22 @@ variables:
       brightness_down: button_down_short
       brightness_down_repeat: button_down_long
       turn_off: button_down_double
+#YAR - ADD - IKEA RODRET
+    IKEA E2201 RODRET Dimmer:
+      turn_on: button_up_short
+      brightness_up_repeat: button_up_long
+      color_up: button_up_double
+      turn_off: button_down_short
+      brightness_down_repeat: button_down_long
+      color_down: button_down_double
+    IKEA E2201 RODRET Dimmer (#2):
+      brightness_up: button_up_short
+      brightness_up_repeat: button_up_long
+      turn_on: button_up_double
+      brightness_down: button_down_short
+      brightness_down_repeat: button_down_long
+      turn_off: button_down_double
+#YAR - ADD END
     IKEA E1744 SYMFONISK Rotary Remote:
       brightness_down_repeat: rotate_left
       brightness_up_repeat: rotate_right
@@ -397,6 +428,12 @@ trigger:
     event_type: ahb_controller_event
     event_data:
       controller: !input controller_entity
+#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  - platform: event
+    event_type: ahb_controller_event
+    event_data:
+      controller: !input controller_mqtt
+#YAR - ADD END
 condition: []
 action:
   - variables:

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -43,10 +43,10 @@ blueprint:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer (#2)
- #**YAR** - ADD - IKEA RODRET
+# **YAR** - ADD - IKEA RODRET
             - IKEA E2201 RODRET Dimmer
             - IKEA E2201 RODRET Dimmer (#2)
- #**YAR** - ADD - END
+# **YAR** - ADD - END
             - IKEA E1744 SYMFONISK Rotary Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote (#2)
@@ -226,7 +226,7 @@ variables:
       brightness_down: button_down_short
       brightness_down_repeat: button_down_long
       turn_off: button_down_double
- #**YAR** - ADD - IKEA RODRET
+# **YAR** - ADD - IKEA RODRET
     IKEA E2201 RODRET Dimmer:
       turn_on: button_up_short
       brightness_up_repeat: button_up_long
@@ -241,7 +241,7 @@ variables:
       brightness_down: button_down_short
       brightness_down_repeat: button_down_long
       turn_off: button_down_double
- #**YAR** - ADD END
+# **YAR** - ADD END
     IKEA E1744 SYMFONISK Rotary Remote:
       brightness_down_repeat: rotate_left
       brightness_up_repeat: rotate_right

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -43,10 +43,10 @@ blueprint:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer (#2)
-#YAR - ADD - IKEA RODRET
+ #**YAR** - ADD - IKEA RODRET
             - IKEA E2201 RODRET Dimmer
             - IKEA E2201 RODRET Dimmer (#2)
-#YAR - ADD - END
+ #**YAR** - ADD - END
             - IKEA E1744 SYMFONISK Rotary Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote (#2)
@@ -226,7 +226,7 @@ variables:
       brightness_down: button_down_short
       brightness_down_repeat: button_down_long
       turn_off: button_down_double
-#YAR - ADD - IKEA RODRET
+ #**YAR** - ADD - IKEA RODRET
     IKEA E2201 RODRET Dimmer:
       turn_on: button_up_short
       brightness_up_repeat: button_up_long
@@ -241,7 +241,7 @@ variables:
       brightness_down: button_down_short
       brightness_down_repeat: button_down_long
       turn_off: button_down_double
-#YAR - ADD END
+ #**YAR** - ADD END
     IKEA E1744 SYMFONISK Rotary Remote:
       brightness_down_repeat: rotate_left
       brightness_up_repeat: rotate_right

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -33,17 +33,6 @@ blueprint:
       selector:
         entity:
           domain: sensor
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-    controller_mqtt:
-      name: (Required) Controller MQTT Device
-      description: The controller device which will control the Light. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as a Device. This value should match the one specified in the corresponding Controller automation.
-      default: ''
-      selector:
-        device:
-          filter:
-          - integration: mqtt
-          multiple: false
-#YAR - ADD END
     controller_model:
       name: (Required) Controller model
       description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
@@ -428,12 +417,6 @@ trigger:
     event_type: ahb_controller_event
     event_data:
       controller: !input controller_entity
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-  - platform: event
-    event_type: ahb_controller_event
-    event_data:
-      controller: !input controller_mqtt
-#YAR - ADD END
 condition: []
 action:
   - variables:

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -17,6 +17,7 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2022.07.30
+    ℹ️ Version 2025.01.07 - Added support for IKEA RODRET E2202 - yarafie
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/hooks/light/light.yaml
   domain: automation
   input:

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -43,10 +43,10 @@ blueprint:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer (#2)
-# **YAR** - ADD - IKEA RODRET
+            # **YAR** - ADD - IKEA RODRET
             - IKEA E2201 RODRET Dimmer
             - IKEA E2201 RODRET Dimmer (#2)
-# **YAR** - ADD - END
+            # **YAR** - ADD - END
             - IKEA E1744 SYMFONISK Rotary Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote (#2)
@@ -226,7 +226,7 @@ variables:
       brightness_down: button_down_short
       brightness_down_repeat: button_down_long
       turn_off: button_down_double
-# **YAR** - ADD - IKEA RODRET
+    # **YAR** - ADD - IKEA RODRET
     IKEA E2201 RODRET Dimmer:
       turn_on: button_up_short
       brightness_up_repeat: button_up_long
@@ -241,7 +241,7 @@ variables:
       brightness_down: button_down_short
       brightness_down_repeat: button_down_long
       turn_off: button_down_double
-# **YAR** - ADD END
+    # **YAR** - ADD END
     IKEA E1744 SYMFONISK Rotary Remote:
       brightness_down_repeat: rotate_left
       brightness_up_repeat: rotate_right

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -33,6 +33,17 @@ blueprint:
       selector:
         entity:
           domain: sensor
+#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+    controller_mqtt:
+      name: (Required) Controller MQTT Device
+      description: The controller device which will control the Media Player. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as a Device. This value should match the one specified in the corresponding Controller automation.
+      default: ''
+      selector:
+        device:
+          filter:
+          - integration: mqtt
+          multiple: false
+#YAR - ADD END
     controller_model:
       name: (Required) Controller model
       description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
@@ -41,6 +52,9 @@ blueprint:
           options:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+#YAR - ADD - IKEA RODRET
+            - IKEA E2201 RODRET Dimmer
+#YAR - ADD - END
             - IKEA E1744 SYMFONISK Rotary Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1812 TRÅDFRI Shortcut button
@@ -108,6 +122,14 @@ variables:
       next_track: button_up_double
       volume_down: button_down_long
       play_pause: button_down_double
+#YAR - ADD - IKEA RODRET
+    IKEA E2201 RODRET Dimmer:
+      volume_up: button_up_short
+      volume_up_repeat: button_up_long
+      next_track: button_up_double
+      volume_down: button_down_long
+      play_pause: button_down_double
+#YAR - ADD END
     IKEA E1744 SYMFONISK Rotary Remote:
       volume_down_repeat: rotate_left
       volume_up_repeat: rotate_right
@@ -234,6 +256,12 @@ trigger:
     event_type: ahb_controller_event
     event_data:
       controller: !input controller_entity
+#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
+  - platform: event
+    event_type: ahb_controller_event
+    event_data:
+      controller: !input controller_mqtt
+#YAR - ADD END
 condition: []
 action:
   - variables:

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -17,7 +17,7 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2022.07.30
-    ℹ️ Version 2025.01.07 - Added support for IKEA RODRET E2202 - yarafie
+    ℹ️ Version 2025.01.07 - Added support for IKEA RODRET (E2201) - yarafie
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/hooks/media_player/media_player.yaml
   domain: automation
   input:

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -42,9 +42,9 @@ blueprint:
           options:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
-#YAR - ADD - IKEA RODRET
+ #**YAR** - ADD - IKEA RODRET
             - IKEA E2201 RODRET Dimmer
-#YAR - ADD - END
+ #**YAR** - ADD - END
             - IKEA E1744 SYMFONISK Rotary Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1812 TRÅDFRI Shortcut button
@@ -112,14 +112,14 @@ variables:
       next_track: button_up_double
       volume_down: button_down_long
       play_pause: button_down_double
-#YAR - ADD - IKEA RODRET
+ #**YAR** - ADD - IKEA RODRET
     IKEA E2201 RODRET Dimmer:
       volume_up: button_up_short
       volume_up_repeat: button_up_long
       next_track: button_up_double
       volume_down: button_down_long
       play_pause: button_down_double
-#YAR - ADD END
+ #**YAR** - ADD END
     IKEA E1744 SYMFONISK Rotary Remote:
       volume_down_repeat: rotate_left
       volume_up_repeat: rotate_right

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -17,6 +17,7 @@ blueprint:
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
     ℹ️ Version 2022.07.30
+    ℹ️ Version 2025.01.07 - Added support for IKEA RODRET E2202 - yarafie
   source_url: https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/blueprints/hooks/media_player/media_player.yaml
   domain: automation
   input:

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -33,17 +33,6 @@ blueprint:
       selector:
         entity:
           domain: sensor
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-    controller_mqtt:
-      name: (Required) Controller MQTT Device
-      description: The controller device which will control the Media Player. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as a Device. This value should match the one specified in the corresponding Controller automation.
-      default: ''
-      selector:
-        device:
-          filter:
-          - integration: mqtt
-          multiple: false
-#YAR - ADD END
     controller_model:
       name: (Required) Controller model
       description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
@@ -256,12 +245,6 @@ trigger:
     event_type: ahb_controller_event
     event_data:
       controller: !input controller_entity
-#YAR - ADD - To Support Zigbee2MQTT v2.0.0 with legacy=false
-  - platform: event
-    event_type: ahb_controller_event
-    event_data:
-      controller: !input controller_mqtt
-#YAR - ADD END
 condition: []
 action:
   - variables:

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -42,9 +42,9 @@ blueprint:
           options:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
-# **YAR** - ADD - IKEA RODRET
+            # **YAR** - ADD - IKEA RODRET
             - IKEA E2201 RODRET Dimmer
-# **YAR** - ADD - END
+            # **YAR** - ADD - END
             - IKEA E1744 SYMFONISK Rotary Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1812 TRÅDFRI Shortcut button
@@ -112,14 +112,14 @@ variables:
       next_track: button_up_double
       volume_down: button_down_long
       play_pause: button_down_double
-# **YAR** - ADD - IKEA RODRET
+    # **YAR** - ADD - IKEA RODRET
     IKEA E2201 RODRET Dimmer:
       volume_up: button_up_short
       volume_up_repeat: button_up_long
       next_track: button_up_double
       volume_down: button_down_long
       play_pause: button_down_double
-# **YAR** - ADD END
+    # **YAR** - ADD END
     IKEA E1744 SYMFONISK Rotary Remote:
       volume_down_repeat: rotate_left
       volume_up_repeat: rotate_right

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -42,9 +42,9 @@ blueprint:
           options:
             - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
             - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
- #**YAR** - ADD - IKEA RODRET
+# **YAR** - ADD - IKEA RODRET
             - IKEA E2201 RODRET Dimmer
- #**YAR** - ADD - END
+# **YAR** - ADD - END
             - IKEA E1744 SYMFONISK Rotary Remote
             - IKEA E1766 TRÅDFRI Open/Close Remote
             - IKEA E1812 TRÅDFRI Shortcut button
@@ -112,14 +112,14 @@ variables:
       next_track: button_up_double
       volume_down: button_down_long
       play_pause: button_down_double
- #**YAR** - ADD - IKEA RODRET
+# **YAR** - ADD - IKEA RODRET
     IKEA E2201 RODRET Dimmer:
       volume_up: button_up_short
       volume_up_repeat: button_up_long
       next_track: button_up_double
       volume_down: button_down_long
       play_pause: button_down_double
- #**YAR** - ADD END
+# **YAR** - ADD END
     IKEA E1744 SYMFONISK Rotary Remote:
       volume_down_repeat: rotate_left
       volume_up_repeat: rotate_right

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "awesome-ha-blueprints",
       "version": "0.1.0",
       "devDependencies": {
-        "prettier": "^2.7.1"
+        "prettier": "^2.8.4"
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -29,9 +29,9 @@
   },
   "dependencies": {
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "format": "prettier --write ."
   },
   "devDependencies": {
-    "prettier": "^2.7.1"
+    "prettier": "^2.8.4"
   }
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7767,9 +7767,9 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "requires": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6488,9 +6488,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
+      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
       "dev": true
     },
     "eslint-import-resolver-node": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9972,9 +9972,9 @@
       "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA=="
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true
     },
     "pretty-error": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3846,9 +3846,9 @@
       }
     },
     "@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "@sideway/pinpoint": {
       "version": "2.0.0",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3524,15 +3524,15 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
+      "integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.2",
-        "globals": "^13.15.0",
+        "espree": "^9.4.0",
+        "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -3541,9 +3541,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+          "version": "13.20.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+          "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -3563,6 +3563,12 @@
         }
       }
     },
+    "@eslint/js": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
+      "integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
+      "dev": true
+    },
     "@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -3577,20 +3583,20 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
-    "@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true
     },
     "@humanwhocodes/object-schema": {
@@ -6263,14 +6269,16 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
     "eslint": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
-      "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
+      "integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.0",
-        "@humanwhocodes/config-array": "^0.10.4",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@eslint/eslintrc": "^2.0.0",
+        "@eslint/js": "8.35.0",
+        "@humanwhocodes/config-array": "^0.11.8",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -6280,21 +6288,21 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.3",
-        "esquery": "^1.4.0",
+        "espree": "^9.4.0",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^6.0.1",
-        "globals": "^13.15.0",
-        "globby": "^11.1.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -6305,8 +6313,7 @@
         "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6385,9 +6392,9 @@
           }
         },
         "globals": {
-          "version": "13.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+          "version": "13.20.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+          "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -6699,9 +6706,9 @@
       "dev": true
     },
     "espree": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.0",
@@ -6710,9 +6717,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+          "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
           "dev": true
         }
       }
@@ -6723,9 +6730,9 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
+      "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -7094,9 +7101,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
     "flux": {
@@ -7273,12 +7280,6 @@
         "es-abstract": "^1.19.0",
         "functions-have-names": "^1.2.2"
       }
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
     },
     "functions-have-names": {
       "version": "1.2.3",
@@ -8278,6 +8279,12 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "js-sdsl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -11847,12 +11854,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    },
-    "v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
     },
     "value-equal": {
       "version": "1.0.1",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8636,12 +8636,30 @@
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+          "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+          "requires": {
+            "fill-range": "^7.1.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+          "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        }
       }
     },
     "mime": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8433,9 +8433,9 @@
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
     },
     "loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11692,9 +11692,9 @@
       }
     },
     "ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1065,22 +1065,22 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.18.10.tgz",
-      "integrity": "sha512-q5mMeYAdfEbpBAgzl7tBre/la3LeCxmDO1+wMXRdPWbcoMjR3GiXlCLk7JBZVVye0bqTGNMbt0yYVXX1B1jEWQ==",
+      "version": "7.19.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.19.6.tgz",
+      "integrity": "sha512-PRH37lz4JU156lYFW1p8OxE5i7d6Sl/zV58ooyr+q1J1lnQPyg5tIiXlIwNVhJaY4W3TmOtdc8jqdXQcB1v5Yw==",
       "requires": {
         "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.9",
-        "babel-plugin-polyfill-corejs2": "^0.3.2",
-        "babel-plugin-polyfill-corejs3": "^0.5.3",
-        "babel-plugin-polyfill-regenerator": "^0.4.0",
+        "@babel/helper-plugin-utils": "^7.19.0",
+        "babel-plugin-polyfill-corejs2": "^0.3.3",
+        "babel-plugin-polyfill-corejs3": "^0.6.0",
+        "babel-plugin-polyfill-regenerator": "^0.4.1",
         "semver": "^6.3.0"
       },
       "dependencies": {
         "@babel/helper-define-polyfill-provider": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.2.tgz",
-          "integrity": "sha512-r9QJJ+uDWrd+94BSPcP6/de67ygLtvVy6cK4luE6MOuDsZIdoaPBnfSpbO/+LTifjPckbKXRuI9BB/Z2/y3iTg==",
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
+          "integrity": "sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==",
           "requires": {
             "@babel/helper-compilation-targets": "^7.17.7",
             "@babel/helper-plugin-utils": "^7.16.7",
@@ -1090,37 +1090,85 @@
             "semver": "^6.1.2"
           }
         },
+        "@babel/helper-plugin-utils": {
+          "version": "7.20.2",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+          "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ=="
+        },
         "babel-plugin-polyfill-corejs2": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.2.tgz",
-          "integrity": "sha512-LPnodUl3lS0/4wN3Rb+m+UK8s7lj2jcLRrjho4gLw+OJs+I4bvGXshINesY5xx/apM+biTnQ9reDI8yj+0M5+Q==",
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+          "integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
           "requires": {
             "@babel/compat-data": "^7.17.7",
-            "@babel/helper-define-polyfill-provider": "^0.3.2",
+            "@babel/helper-define-polyfill-provider": "^0.3.3",
             "semver": "^6.1.1"
           }
         },
         "babel-plugin-polyfill-corejs3": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.3.tgz",
-          "integrity": "sha512-zKsXDh0XjnrUEW0mxIHLfjBfnXSMr5Q/goMe/fxpQnLm07mcOZiIZHBNWCMx60HmdvjxfXcalac0tfFg0wqxyw==",
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
+          "integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
           "requires": {
-            "@babel/helper-define-polyfill-provider": "^0.3.2",
-            "core-js-compat": "^3.21.0"
+            "@babel/helper-define-polyfill-provider": "^0.3.3",
+            "core-js-compat": "^3.25.1"
           }
         },
         "babel-plugin-polyfill-regenerator": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.0.tgz",
-          "integrity": "sha512-RW1cnryiADFeHmfLS+WW/G431p1PsW5qdRdz0SDRi7TKcUgc7Oh/uXkT7MZ/+tGsT1BkczEAmD5XjUyJ5SWDTw==",
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
+          "integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
           "requires": {
-            "@babel/helper-define-polyfill-provider": "^0.3.2"
+            "@babel/helper-define-polyfill-provider": "^0.3.3"
           }
+        },
+        "browserslist": {
+          "version": "4.21.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+          "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001449",
+            "electron-to-chromium": "^1.4.284",
+            "node-releases": "^2.0.8",
+            "update-browserslist-db": "^1.0.10"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001450",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz",
+          "integrity": "sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew=="
+        },
+        "core-js-compat": {
+          "version": "3.27.2",
+          "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.27.2.tgz",
+          "integrity": "sha512-welaYuF7ZtbYKGrIy7y3eb40d37rG1FvzEOfe7hSLd2iD6duMDqUhRfSvCGyC46HhR6Y8JXXdZ2lnRUMkPBpvg==",
+          "requires": {
+            "browserslist": "^4.21.4"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.4.286",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.286.tgz",
+          "integrity": "sha512-Vp3CVhmYpgf4iXNKAucoQUDcCrBQX3XLBtwgFqP9BUXuucgvAV9zWp1kYU7LL9j4++s9O+12cb3wMtN4SJy6UQ=="
+        },
+        "node-releases": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.9.tgz",
+          "integrity": "sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA=="
         },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "update-browserslist-db": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+          "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+          "requires": {
+            "escalade": "^3.1.1",
+            "picocolors": "^1.0.0"
+          }
         }
       }
     },
@@ -1392,9 +1440,9 @@
       }
     },
     "@docusaurus/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
+      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
       "requires": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -1406,13 +1454,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/cssnano-preset": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -1433,7 +1481,7 @@
         "del": "^6.1.1",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "html-minifier-terser": "^6.1.0",
@@ -1470,23 +1518,23 @@
       },
       "dependencies": {
         "@docusaurus/logger": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.1.tgz",
-          "integrity": "sha512-wIWseCKko1w/WARcDjO3N/XoJ0q/VE42AthP0eNAfEazDjJ94NXbaI6wuUsuY/bMg6hTKGVIpphjj2LoX3g6dA==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.3.1.tgz",
+          "integrity": "sha512-2lAV/olKKVr9qJhfHFCaqBIl8FgYjbUFwgUnX76+cULwQYss+42ZQ3grHGFvI0ocN2X55WcYe64ellQXz7suqg==",
           "requires": {
             "chalk": "^4.1.2",
             "tslib": "^2.4.0"
           }
         },
         "@docusaurus/mdx-loader": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.1.tgz",
-          "integrity": "sha512-tdNeljdilXCmhbaEND3SAgsqaw/oh7v9onT5yrIrL26OSk2AFwd+MIi4R8jt8vq33M0R4rz2wpknm0fQIkDdvQ==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.3.1.tgz",
+          "integrity": "sha512-Gzga7OsxQRpt3392K9lv/bW4jGppdLFJh3luKRknCKSAaZrmVkOQv2gvCn8LAOSZ3uRg5No7AgYs/vpL8K94lA==",
           "requires": {
             "@babel/parser": "^7.18.8",
             "@babel/traverse": "^7.18.8",
-            "@docusaurus/logger": "2.0.1",
-            "@docusaurus/utils": "2.0.1",
+            "@docusaurus/logger": "2.3.1",
+            "@docusaurus/utils": "2.3.1",
             "@mdx-js/mdx": "^1.6.22",
             "escape-html": "^1.0.3",
             "file-loader": "^6.2.0",
@@ -1503,12 +1551,13 @@
           }
         },
         "@docusaurus/utils": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.1.tgz",
-          "integrity": "sha512-u2Vdl/eoVwMfUjDCkg7FjxoiwFs/XhVVtNxQEw8cvB+qaw6QWyT73m96VZzWtUb1fDOefHoZ+bZ0ObFeKk9lMQ==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.3.1.tgz",
+          "integrity": "sha512-9WcQROCV0MmrpOQDXDGhtGMd52DHpSFbKLfkyaYumzbTstrbA5pPOtiGtxK1nqUHkiIv8UwexS54p0Vod2I1lg==",
           "requires": {
-            "@docusaurus/logger": "2.0.1",
+            "@docusaurus/logger": "2.3.1",
             "@svgr/webpack": "^6.2.1",
+            "escape-string-regexp": "^4.0.0",
             "file-loader": "^6.2.0",
             "fs-extra": "^10.1.0",
             "github-slugger": "^1.4.0",
@@ -1525,20 +1574,20 @@
           }
         },
         "@docusaurus/utils-common": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.1.tgz",
-          "integrity": "sha512-kajCCDCXRd1HFH5EUW31MPaQcsyNlGakpkDoTBtBvpa4EIPvWaSKy7TIqYKHrZjX4tnJ0YbEJvaXfjjgdq5xSg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.3.1.tgz",
+          "integrity": "sha512-pVlRpXkdNcxmKNxAaB1ya2hfCEvVsLDp2joeM6K6uv55Oc5nVIqgyYSgSNKZyMdw66NnvMfsu0RBylcwZQKo9A==",
           "requires": {
             "tslib": "^2.4.0"
           }
         },
         "@docusaurus/utils-validation": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.1.tgz",
-          "integrity": "sha512-f14AnwFBy4/1A19zWthK+Ii80YDz+4qt8oPpK3julywXsheSxPBqgsND3LVBBvB2p3rJHvbo2m3HyB9Tco1JRw==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.3.1.tgz",
+          "integrity": "sha512-7n0208IG3k1HVTByMHlZoIDjjOFC8sbViHVXJx0r3Q+3Ezrx+VQ1RZ/zjNn6lT+QBCRCXlnlaoJ8ug4HIVgQ3w==",
           "requires": {
-            "@docusaurus/logger": "2.0.1",
-            "@docusaurus/utils": "2.0.1",
+            "@docusaurus/logger": "2.3.1",
+            "@docusaurus/utils": "2.3.1",
             "joi": "^17.6.0",
             "js-yaml": "^4.1.0",
             "tslib": "^2.4.0"
@@ -1574,6 +1623,16 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "eta": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.0.tgz",
+          "integrity": "sha512-NqE7S2VmVwgMS8yBxsH4VgNQjNjLq1gfGU0u9I6Cjh468nPRMoDfGdK9n1p/3Dvsw3ebklDkZsFAnKJ9sefjBA=="
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1603,9 +1662,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
-      "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
+      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -1753,6 +1812,151 @@
         "unist-util-visit": "^2.0.3",
         "utility-types": "^3.10.0",
         "webpack": "^5.73.0"
+      },
+      "dependencies": {
+        "@docusaurus/core": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+          "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+          "requires": {
+            "@babel/core": "^7.18.6",
+            "@babel/generator": "^7.18.7",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.18.6",
+            "@babel/preset-env": "^7.18.6",
+            "@babel/preset-react": "^7.18.6",
+            "@babel/preset-typescript": "^7.18.6",
+            "@babel/runtime": "^7.18.6",
+            "@babel/runtime-corejs3": "^7.18.6",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/cssnano-preset": "2.0.1",
+            "@docusaurus/logger": "2.0.1",
+            "@docusaurus/mdx-loader": "2.0.1",
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/utils": "2.0.1",
+            "@docusaurus/utils-common": "2.0.1",
+            "@docusaurus/utils-validation": "2.0.1",
+            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+            "@svgr/webpack": "^6.2.1",
+            "autoprefixer": "^10.4.7",
+            "babel-loader": "^8.2.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.0",
+            "cli-table3": "^0.6.2",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.23.3",
+            "css-loader": "^6.7.1",
+            "css-minimizer-webpack-plugin": "^4.0.0",
+            "cssnano": "^5.1.12",
+            "del": "^6.1.1",
+            "detect-port": "^1.3.0",
+            "escape-html": "^1.0.3",
+            "eta": "^1.12.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "html-minifier-terser": "^6.1.0",
+            "html-tags": "^3.2.0",
+            "html-webpack-plugin": "^5.5.0",
+            "import-fresh": "^3.3.0",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.6.1",
+            "postcss": "^8.4.14",
+            "postcss-loader": "^7.0.0",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.3",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.3",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.3.7",
+            "serve-handler": "^6.1.3",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.3",
+            "tslib": "^2.4.0",
+            "update-notifier": "^5.1.0",
+            "url-loader": "^4.1.1",
+            "wait-on": "^6.0.1",
+            "webpack": "^5.73.0",
+            "webpack-bundle-analyzer": "^4.5.0",
+            "webpack-dev-server": "^4.9.3",
+            "webpack-merge": "^5.8.0",
+            "webpackbar": "^5.0.2"
+          },
+          "dependencies": {
+            "react-loadable": {
+              "version": "npm:@docusaurus/react-loadable@5.5.2",
+              "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+              "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+              "requires": {
+                "@types/react": "*",
+                "prop-types": "^15.6.2"
+              }
+            }
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+          "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.8",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-content-docs": {
@@ -1776,6 +1980,151 @@
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0",
         "webpack": "^5.73.0"
+      },
+      "dependencies": {
+        "@docusaurus/core": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+          "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+          "requires": {
+            "@babel/core": "^7.18.6",
+            "@babel/generator": "^7.18.7",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.18.6",
+            "@babel/preset-env": "^7.18.6",
+            "@babel/preset-react": "^7.18.6",
+            "@babel/preset-typescript": "^7.18.6",
+            "@babel/runtime": "^7.18.6",
+            "@babel/runtime-corejs3": "^7.18.6",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/cssnano-preset": "2.0.1",
+            "@docusaurus/logger": "2.0.1",
+            "@docusaurus/mdx-loader": "2.0.1",
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/utils": "2.0.1",
+            "@docusaurus/utils-common": "2.0.1",
+            "@docusaurus/utils-validation": "2.0.1",
+            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+            "@svgr/webpack": "^6.2.1",
+            "autoprefixer": "^10.4.7",
+            "babel-loader": "^8.2.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.0",
+            "cli-table3": "^0.6.2",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.23.3",
+            "css-loader": "^6.7.1",
+            "css-minimizer-webpack-plugin": "^4.0.0",
+            "cssnano": "^5.1.12",
+            "del": "^6.1.1",
+            "detect-port": "^1.3.0",
+            "escape-html": "^1.0.3",
+            "eta": "^1.12.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "html-minifier-terser": "^6.1.0",
+            "html-tags": "^3.2.0",
+            "html-webpack-plugin": "^5.5.0",
+            "import-fresh": "^3.3.0",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.6.1",
+            "postcss": "^8.4.14",
+            "postcss-loader": "^7.0.0",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.3",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.3",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.3.7",
+            "serve-handler": "^6.1.3",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.3",
+            "tslib": "^2.4.0",
+            "update-notifier": "^5.1.0",
+            "url-loader": "^4.1.1",
+            "wait-on": "^6.0.1",
+            "webpack": "^5.73.0",
+            "webpack-bundle-analyzer": "^4.5.0",
+            "webpack-dev-server": "^4.9.3",
+            "webpack-merge": "^5.8.0",
+            "webpackbar": "^5.0.2"
+          },
+          "dependencies": {
+            "react-loadable": {
+              "version": "npm:@docusaurus/react-loadable@5.5.2",
+              "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+              "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+              "requires": {
+                "@types/react": "*",
+                "prop-types": "^15.6.2"
+              }
+            }
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+          "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.8",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-content-pages": {
@@ -1791,6 +2140,151 @@
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
+      },
+      "dependencies": {
+        "@docusaurus/core": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+          "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+          "requires": {
+            "@babel/core": "^7.18.6",
+            "@babel/generator": "^7.18.7",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.18.6",
+            "@babel/preset-env": "^7.18.6",
+            "@babel/preset-react": "^7.18.6",
+            "@babel/preset-typescript": "^7.18.6",
+            "@babel/runtime": "^7.18.6",
+            "@babel/runtime-corejs3": "^7.18.6",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/cssnano-preset": "2.0.1",
+            "@docusaurus/logger": "2.0.1",
+            "@docusaurus/mdx-loader": "2.0.1",
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/utils": "2.0.1",
+            "@docusaurus/utils-common": "2.0.1",
+            "@docusaurus/utils-validation": "2.0.1",
+            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+            "@svgr/webpack": "^6.2.1",
+            "autoprefixer": "^10.4.7",
+            "babel-loader": "^8.2.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.0",
+            "cli-table3": "^0.6.2",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.23.3",
+            "css-loader": "^6.7.1",
+            "css-minimizer-webpack-plugin": "^4.0.0",
+            "cssnano": "^5.1.12",
+            "del": "^6.1.1",
+            "detect-port": "^1.3.0",
+            "escape-html": "^1.0.3",
+            "eta": "^1.12.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "html-minifier-terser": "^6.1.0",
+            "html-tags": "^3.2.0",
+            "html-webpack-plugin": "^5.5.0",
+            "import-fresh": "^3.3.0",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.6.1",
+            "postcss": "^8.4.14",
+            "postcss-loader": "^7.0.0",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.3",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.3",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.3.7",
+            "serve-handler": "^6.1.3",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.3",
+            "tslib": "^2.4.0",
+            "update-notifier": "^5.1.0",
+            "url-loader": "^4.1.1",
+            "wait-on": "^6.0.1",
+            "webpack": "^5.73.0",
+            "webpack-bundle-analyzer": "^4.5.0",
+            "webpack-dev-server": "^4.9.3",
+            "webpack-merge": "^5.8.0",
+            "webpackbar": "^5.0.2"
+          },
+          "dependencies": {
+            "react-loadable": {
+              "version": "npm:@docusaurus/react-loadable@5.5.2",
+              "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+              "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+              "requires": {
+                "@types/react": "*",
+                "prop-types": "^15.6.2"
+              }
+            }
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+          "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.8",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-debug": {
@@ -1804,6 +2298,151 @@
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@docusaurus/core": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+          "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+          "requires": {
+            "@babel/core": "^7.18.6",
+            "@babel/generator": "^7.18.7",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.18.6",
+            "@babel/preset-env": "^7.18.6",
+            "@babel/preset-react": "^7.18.6",
+            "@babel/preset-typescript": "^7.18.6",
+            "@babel/runtime": "^7.18.6",
+            "@babel/runtime-corejs3": "^7.18.6",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/cssnano-preset": "2.0.1",
+            "@docusaurus/logger": "2.0.1",
+            "@docusaurus/mdx-loader": "2.0.1",
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/utils": "2.0.1",
+            "@docusaurus/utils-common": "2.0.1",
+            "@docusaurus/utils-validation": "2.0.1",
+            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+            "@svgr/webpack": "^6.2.1",
+            "autoprefixer": "^10.4.7",
+            "babel-loader": "^8.2.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.0",
+            "cli-table3": "^0.6.2",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.23.3",
+            "css-loader": "^6.7.1",
+            "css-minimizer-webpack-plugin": "^4.0.0",
+            "cssnano": "^5.1.12",
+            "del": "^6.1.1",
+            "detect-port": "^1.3.0",
+            "escape-html": "^1.0.3",
+            "eta": "^1.12.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "html-minifier-terser": "^6.1.0",
+            "html-tags": "^3.2.0",
+            "html-webpack-plugin": "^5.5.0",
+            "import-fresh": "^3.3.0",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.6.1",
+            "postcss": "^8.4.14",
+            "postcss-loader": "^7.0.0",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.3",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.3",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.3.7",
+            "serve-handler": "^6.1.3",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.3",
+            "tslib": "^2.4.0",
+            "update-notifier": "^5.1.0",
+            "url-loader": "^4.1.1",
+            "wait-on": "^6.0.1",
+            "webpack": "^5.73.0",
+            "webpack-bundle-analyzer": "^4.5.0",
+            "webpack-dev-server": "^4.9.3",
+            "webpack-merge": "^5.8.0",
+            "webpackbar": "^5.0.2"
+          },
+          "dependencies": {
+            "react-loadable": {
+              "version": "npm:@docusaurus/react-loadable@5.5.2",
+              "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+              "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+              "requires": {
+                "@types/react": "*",
+                "prop-types": "^15.6.2"
+              }
+            }
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+          "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.8",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-google-analytics": {
@@ -1815,6 +2454,151 @@
         "@docusaurus/types": "2.0.1",
         "@docusaurus/utils-validation": "2.0.1",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@docusaurus/core": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+          "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+          "requires": {
+            "@babel/core": "^7.18.6",
+            "@babel/generator": "^7.18.7",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.18.6",
+            "@babel/preset-env": "^7.18.6",
+            "@babel/preset-react": "^7.18.6",
+            "@babel/preset-typescript": "^7.18.6",
+            "@babel/runtime": "^7.18.6",
+            "@babel/runtime-corejs3": "^7.18.6",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/cssnano-preset": "2.0.1",
+            "@docusaurus/logger": "2.0.1",
+            "@docusaurus/mdx-loader": "2.0.1",
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/utils": "2.0.1",
+            "@docusaurus/utils-common": "2.0.1",
+            "@docusaurus/utils-validation": "2.0.1",
+            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+            "@svgr/webpack": "^6.2.1",
+            "autoprefixer": "^10.4.7",
+            "babel-loader": "^8.2.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.0",
+            "cli-table3": "^0.6.2",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.23.3",
+            "css-loader": "^6.7.1",
+            "css-minimizer-webpack-plugin": "^4.0.0",
+            "cssnano": "^5.1.12",
+            "del": "^6.1.1",
+            "detect-port": "^1.3.0",
+            "escape-html": "^1.0.3",
+            "eta": "^1.12.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "html-minifier-terser": "^6.1.0",
+            "html-tags": "^3.2.0",
+            "html-webpack-plugin": "^5.5.0",
+            "import-fresh": "^3.3.0",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.6.1",
+            "postcss": "^8.4.14",
+            "postcss-loader": "^7.0.0",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.3",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.3",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.3.7",
+            "serve-handler": "^6.1.3",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.3",
+            "tslib": "^2.4.0",
+            "update-notifier": "^5.1.0",
+            "url-loader": "^4.1.1",
+            "wait-on": "^6.0.1",
+            "webpack": "^5.73.0",
+            "webpack-bundle-analyzer": "^4.5.0",
+            "webpack-dev-server": "^4.9.3",
+            "webpack-merge": "^5.8.0",
+            "webpackbar": "^5.0.2"
+          },
+          "dependencies": {
+            "react-loadable": {
+              "version": "npm:@docusaurus/react-loadable@5.5.2",
+              "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+              "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+              "requires": {
+                "@types/react": "*",
+                "prop-types": "^15.6.2"
+              }
+            }
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+          "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.8",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-google-gtag": {
@@ -1826,6 +2610,151 @@
         "@docusaurus/types": "2.0.1",
         "@docusaurus/utils-validation": "2.0.1",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@docusaurus/core": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+          "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+          "requires": {
+            "@babel/core": "^7.18.6",
+            "@babel/generator": "^7.18.7",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.18.6",
+            "@babel/preset-env": "^7.18.6",
+            "@babel/preset-react": "^7.18.6",
+            "@babel/preset-typescript": "^7.18.6",
+            "@babel/runtime": "^7.18.6",
+            "@babel/runtime-corejs3": "^7.18.6",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/cssnano-preset": "2.0.1",
+            "@docusaurus/logger": "2.0.1",
+            "@docusaurus/mdx-loader": "2.0.1",
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/utils": "2.0.1",
+            "@docusaurus/utils-common": "2.0.1",
+            "@docusaurus/utils-validation": "2.0.1",
+            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+            "@svgr/webpack": "^6.2.1",
+            "autoprefixer": "^10.4.7",
+            "babel-loader": "^8.2.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.0",
+            "cli-table3": "^0.6.2",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.23.3",
+            "css-loader": "^6.7.1",
+            "css-minimizer-webpack-plugin": "^4.0.0",
+            "cssnano": "^5.1.12",
+            "del": "^6.1.1",
+            "detect-port": "^1.3.0",
+            "escape-html": "^1.0.3",
+            "eta": "^1.12.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "html-minifier-terser": "^6.1.0",
+            "html-tags": "^3.2.0",
+            "html-webpack-plugin": "^5.5.0",
+            "import-fresh": "^3.3.0",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.6.1",
+            "postcss": "^8.4.14",
+            "postcss-loader": "^7.0.0",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.3",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.3",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.3.7",
+            "serve-handler": "^6.1.3",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.3",
+            "tslib": "^2.4.0",
+            "update-notifier": "^5.1.0",
+            "url-loader": "^4.1.1",
+            "wait-on": "^6.0.1",
+            "webpack": "^5.73.0",
+            "webpack-bundle-analyzer": "^4.5.0",
+            "webpack-dev-server": "^4.9.3",
+            "webpack-merge": "^5.8.0",
+            "webpackbar": "^5.0.2"
+          },
+          "dependencies": {
+            "react-loadable": {
+              "version": "npm:@docusaurus/react-loadable@5.5.2",
+              "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+              "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+              "requires": {
+                "@types/react": "*",
+                "prop-types": "^15.6.2"
+              }
+            }
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+          "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.8",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-sitemap": {
@@ -1842,6 +2771,151 @@
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@docusaurus/core": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+          "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+          "requires": {
+            "@babel/core": "^7.18.6",
+            "@babel/generator": "^7.18.7",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.18.6",
+            "@babel/preset-env": "^7.18.6",
+            "@babel/preset-react": "^7.18.6",
+            "@babel/preset-typescript": "^7.18.6",
+            "@babel/runtime": "^7.18.6",
+            "@babel/runtime-corejs3": "^7.18.6",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/cssnano-preset": "2.0.1",
+            "@docusaurus/logger": "2.0.1",
+            "@docusaurus/mdx-loader": "2.0.1",
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/utils": "2.0.1",
+            "@docusaurus/utils-common": "2.0.1",
+            "@docusaurus/utils-validation": "2.0.1",
+            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+            "@svgr/webpack": "^6.2.1",
+            "autoprefixer": "^10.4.7",
+            "babel-loader": "^8.2.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.0",
+            "cli-table3": "^0.6.2",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.23.3",
+            "css-loader": "^6.7.1",
+            "css-minimizer-webpack-plugin": "^4.0.0",
+            "cssnano": "^5.1.12",
+            "del": "^6.1.1",
+            "detect-port": "^1.3.0",
+            "escape-html": "^1.0.3",
+            "eta": "^1.12.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "html-minifier-terser": "^6.1.0",
+            "html-tags": "^3.2.0",
+            "html-webpack-plugin": "^5.5.0",
+            "import-fresh": "^3.3.0",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.6.1",
+            "postcss": "^8.4.14",
+            "postcss-loader": "^7.0.0",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.3",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.3",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.3.7",
+            "serve-handler": "^6.1.3",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.3",
+            "tslib": "^2.4.0",
+            "update-notifier": "^5.1.0",
+            "url-loader": "^4.1.1",
+            "wait-on": "^6.0.1",
+            "webpack": "^5.73.0",
+            "webpack-bundle-analyzer": "^4.5.0",
+            "webpack-dev-server": "^4.9.3",
+            "webpack-merge": "^5.8.0",
+            "webpackbar": "^5.0.2"
+          },
+          "dependencies": {
+            "react-loadable": {
+              "version": "npm:@docusaurus/react-loadable@5.5.2",
+              "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+              "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+              "requires": {
+                "@types/react": "*",
+                "prop-types": "^15.6.2"
+              }
+            }
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+          "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.8",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@docusaurus/preset-classic": {
@@ -1861,6 +2935,151 @@
         "@docusaurus/theme-common": "2.0.1",
         "@docusaurus/theme-search-algolia": "2.0.1",
         "@docusaurus/types": "2.0.1"
+      },
+      "dependencies": {
+        "@docusaurus/core": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+          "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+          "requires": {
+            "@babel/core": "^7.18.6",
+            "@babel/generator": "^7.18.7",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.18.6",
+            "@babel/preset-env": "^7.18.6",
+            "@babel/preset-react": "^7.18.6",
+            "@babel/preset-typescript": "^7.18.6",
+            "@babel/runtime": "^7.18.6",
+            "@babel/runtime-corejs3": "^7.18.6",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/cssnano-preset": "2.0.1",
+            "@docusaurus/logger": "2.0.1",
+            "@docusaurus/mdx-loader": "2.0.1",
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/utils": "2.0.1",
+            "@docusaurus/utils-common": "2.0.1",
+            "@docusaurus/utils-validation": "2.0.1",
+            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+            "@svgr/webpack": "^6.2.1",
+            "autoprefixer": "^10.4.7",
+            "babel-loader": "^8.2.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.0",
+            "cli-table3": "^0.6.2",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.23.3",
+            "css-loader": "^6.7.1",
+            "css-minimizer-webpack-plugin": "^4.0.0",
+            "cssnano": "^5.1.12",
+            "del": "^6.1.1",
+            "detect-port": "^1.3.0",
+            "escape-html": "^1.0.3",
+            "eta": "^1.12.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "html-minifier-terser": "^6.1.0",
+            "html-tags": "^3.2.0",
+            "html-webpack-plugin": "^5.5.0",
+            "import-fresh": "^3.3.0",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.6.1",
+            "postcss": "^8.4.14",
+            "postcss-loader": "^7.0.0",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.3",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.3",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.3.7",
+            "serve-handler": "^6.1.3",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.3",
+            "tslib": "^2.4.0",
+            "update-notifier": "^5.1.0",
+            "url-loader": "^4.1.1",
+            "wait-on": "^6.0.1",
+            "webpack": "^5.73.0",
+            "webpack-bundle-analyzer": "^4.5.0",
+            "webpack-dev-server": "^4.9.3",
+            "webpack-merge": "^5.8.0",
+            "webpackbar": "^5.0.2"
+          },
+          "dependencies": {
+            "react-loadable": {
+              "version": "npm:@docusaurus/react-loadable@5.5.2",
+              "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+              "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+              "requires": {
+                "@types/react": "*",
+                "prop-types": "^15.6.2"
+              }
+            }
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+          "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.8",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@docusaurus/react-loadable": {
@@ -1902,6 +3121,151 @@
         "rtlcss": "^3.5.0",
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0"
+      },
+      "dependencies": {
+        "@docusaurus/core": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+          "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+          "requires": {
+            "@babel/core": "^7.18.6",
+            "@babel/generator": "^7.18.7",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.18.6",
+            "@babel/preset-env": "^7.18.6",
+            "@babel/preset-react": "^7.18.6",
+            "@babel/preset-typescript": "^7.18.6",
+            "@babel/runtime": "^7.18.6",
+            "@babel/runtime-corejs3": "^7.18.6",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/cssnano-preset": "2.0.1",
+            "@docusaurus/logger": "2.0.1",
+            "@docusaurus/mdx-loader": "2.0.1",
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/utils": "2.0.1",
+            "@docusaurus/utils-common": "2.0.1",
+            "@docusaurus/utils-validation": "2.0.1",
+            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+            "@svgr/webpack": "^6.2.1",
+            "autoprefixer": "^10.4.7",
+            "babel-loader": "^8.2.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.0",
+            "cli-table3": "^0.6.2",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.23.3",
+            "css-loader": "^6.7.1",
+            "css-minimizer-webpack-plugin": "^4.0.0",
+            "cssnano": "^5.1.12",
+            "del": "^6.1.1",
+            "detect-port": "^1.3.0",
+            "escape-html": "^1.0.3",
+            "eta": "^1.12.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "html-minifier-terser": "^6.1.0",
+            "html-tags": "^3.2.0",
+            "html-webpack-plugin": "^5.5.0",
+            "import-fresh": "^3.3.0",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.6.1",
+            "postcss": "^8.4.14",
+            "postcss-loader": "^7.0.0",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.3",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.3",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.3.7",
+            "serve-handler": "^6.1.3",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.3",
+            "tslib": "^2.4.0",
+            "update-notifier": "^5.1.0",
+            "url-loader": "^4.1.1",
+            "wait-on": "^6.0.1",
+            "webpack": "^5.73.0",
+            "webpack-bundle-analyzer": "^4.5.0",
+            "webpack-dev-server": "^4.9.3",
+            "webpack-merge": "^5.8.0",
+            "webpackbar": "^5.0.2"
+          },
+          "dependencies": {
+            "react-loadable": {
+              "version": "npm:@docusaurus/react-loadable@5.5.2",
+              "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+              "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+              "requires": {
+                "@types/react": "*",
+                "prop-types": "^15.6.2"
+              }
+            }
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+          "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.8",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@docusaurus/theme-common": {
@@ -1946,6 +3310,151 @@
         "lodash": "^4.17.21",
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0"
+      },
+      "dependencies": {
+        "@docusaurus/core": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+          "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+          "requires": {
+            "@babel/core": "^7.18.6",
+            "@babel/generator": "^7.18.7",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.18.6",
+            "@babel/preset-env": "^7.18.6",
+            "@babel/preset-react": "^7.18.6",
+            "@babel/preset-typescript": "^7.18.6",
+            "@babel/runtime": "^7.18.6",
+            "@babel/runtime-corejs3": "^7.18.6",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/cssnano-preset": "2.0.1",
+            "@docusaurus/logger": "2.0.1",
+            "@docusaurus/mdx-loader": "2.0.1",
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/utils": "2.0.1",
+            "@docusaurus/utils-common": "2.0.1",
+            "@docusaurus/utils-validation": "2.0.1",
+            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+            "@svgr/webpack": "^6.2.1",
+            "autoprefixer": "^10.4.7",
+            "babel-loader": "^8.2.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.0",
+            "cli-table3": "^0.6.2",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.23.3",
+            "css-loader": "^6.7.1",
+            "css-minimizer-webpack-plugin": "^4.0.0",
+            "cssnano": "^5.1.12",
+            "del": "^6.1.1",
+            "detect-port": "^1.3.0",
+            "escape-html": "^1.0.3",
+            "eta": "^1.12.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "html-minifier-terser": "^6.1.0",
+            "html-tags": "^3.2.0",
+            "html-webpack-plugin": "^5.5.0",
+            "import-fresh": "^3.3.0",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.6.1",
+            "postcss": "^8.4.14",
+            "postcss-loader": "^7.0.0",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.3",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.3",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.3.7",
+            "serve-handler": "^6.1.3",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.3",
+            "tslib": "^2.4.0",
+            "update-notifier": "^5.1.0",
+            "url-loader": "^4.1.1",
+            "wait-on": "^6.0.1",
+            "webpack": "^5.73.0",
+            "webpack-bundle-analyzer": "^4.5.0",
+            "webpack-dev-server": "^4.9.3",
+            "webpack-merge": "^5.8.0",
+            "webpackbar": "^5.0.2"
+          },
+          "dependencies": {
+            "react-loadable": {
+              "version": "npm:@docusaurus/react-loadable@5.5.2",
+              "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+              "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+              "requires": {
+                "@types/react": "*",
+                "prop-types": "^15.6.2"
+              }
+            }
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+          "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.8",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@docusaurus/theme-translations": {
@@ -2089,6 +3598,72 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "@jest/schemas": {
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.0.tgz",
+      "integrity": "sha512-0E01f/gOZeNTG76i5eWWSupvSHaIINrTie7vCyjiYFKgzNdyEGd12BUv4oNBFHOqlHDbtoJi3HrQ38KCC90NsQ==",
+      "requires": {
+        "@sinclair/typebox": "^0.25.16"
+      }
+    },
+    "@jest/types": {
+      "version": "29.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.1.tgz",
+      "integrity": "sha512-zbrAXDUOnpJ+FMST2rV7QZOgec8rskg2zv8g2ajeqitp4tvZiyqTCYXANrKsM+ryj5o+LI+ZN2EgU9drrkiwSA==",
+      "requires": {
+        "@jest/schemas": "^29.4.0",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
@@ -2273,6 +3848,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
+    "@sinclair/typebox": {
+      "version": "0.25.21",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
+      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -2477,20 +4057,20 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.16.tgz",
+      "integrity": "sha512-LkKpqRZ7zqXJuvoELakaFYuETHjZkSol8EV6cNnyishutDBCCdv6+dsKPbKkCcIk57qRphOLY5sEgClw1bO3gA==",
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.31",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.30",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
-      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -2523,6 +4103,27 @@
         "@types/node": "*"
       }
     },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g=="
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2543,9 +4144,9 @@
       }
     },
     "@types/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-fccbsHKqFDXClBZTDLA43zl0+TbxyIwyzIzwwhvoJvhNjOErCdeX2xJbURimv2EbSVUGav001PaCJg4mZxMl4w=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
     },
     "@types/node": {
       "version": "18.0.6",
@@ -2665,12 +4266,25 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "@types/ws": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
-      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/yargs": {
+      "version": "17.0.22",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -2844,9 +4458,9 @@
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "address": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/address/-/address-1.2.0.tgz",
-      "integrity": "sha512-tNEZYz5G/zYunxFm7sfhAxkXEuLj3K6BKwv6ZURlsF6yiUQ65z0Q2wZW9L5cPUl9ocofGvXOdFYbFHp0+6MOig=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
+      "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA=="
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -2877,9 +4491,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -2972,9 +4586,9 @@
       }
     },
     "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -3079,12 +4693,12 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "autoprefixer": {
-      "version": "10.4.8",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.8.tgz",
-      "integrity": "sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==",
+      "version": "10.4.13",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
+      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
       "requires": {
-        "browserslist": "^4.21.3",
-        "caniuse-lite": "^1.0.30001373",
+        "browserslist": "^4.21.4",
+        "caniuse-lite": "^1.0.30001426",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -3092,25 +4706,39 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.21.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-          "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+          "version": "4.21.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+          "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
           "requires": {
-            "caniuse-lite": "^1.0.30001370",
-            "electron-to-chromium": "^1.4.202",
-            "node-releases": "^2.0.6",
-            "update-browserslist-db": "^1.0.5"
+            "caniuse-lite": "^1.0.30001449",
+            "electron-to-chromium": "^1.4.284",
+            "node-releases": "^2.0.8",
+            "update-browserslist-db": "^1.0.10"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001373",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
-          "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ=="
+          "version": "1.0.30001450",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz",
+          "integrity": "sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew=="
         },
         "electron-to-chromium": {
-          "version": "1.4.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.206.tgz",
-          "integrity": "sha512-h+Fadt1gIaQ06JaIiyqPsBjJ08fV5Q7md+V8bUvQW/9OvXfL2LRICTz2EcnnCP7QzrFTS6/27MRV6Bl9Yn97zA=="
+          "version": "1.4.286",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.286.tgz",
+          "integrity": "sha512-Vp3CVhmYpgf4iXNKAucoQUDcCrBQX3XLBtwgFqP9BUXuucgvAV9zWp1kYU7LL9j4++s9O+12cb3wMtN4SJy6UQ=="
+        },
+        "node-releases": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.9.tgz",
+          "integrity": "sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA=="
+        },
+        "update-browserslist-db": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+          "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+          "requires": {
+            "escalade": "^3.1.1",
+            "picocolors": "^1.0.0"
+          }
         }
       }
     },
@@ -3135,9 +4763,9 @@
       "dev": true
     },
     "babel-loader": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.5.tgz",
-      "integrity": "sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
+      "integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
       "requires": {
         "find-cache-dir": "^3.3.1",
         "loader-utils": "^2.0.0",
@@ -3261,9 +4889,9 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "body-parser": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "requires": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
@@ -3273,7 +4901,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -3300,9 +4928,9 @@
       }
     },
     "bonjour-service": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.0.13.tgz",
-      "integrity": "sha512-LWKRU/7EqDUC9CTAQtuZl5HzBALoCYwtLhffW3et7vZMwv3bWLpJf8bRYlMD5OCcDpTfnPgNCV4yo9ZIaJGMiA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.0.tgz",
+      "integrity": "sha512-LVRinRB3k1/K0XzZ2p58COnWvkQknIY6sf0zF2rpErvcJXpMBttEPQSxK+HEXSS9VmpZlDoDnQWv8ftJT20B0Q==",
       "requires": {
         "array-flatten": "^2.1.2",
         "dns-equal": "^1.0.0",
@@ -3675,14 +5303,14 @@
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
     },
     "ci-info": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+      "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w=="
     },
     "clean-css": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.1.tgz",
-      "integrity": "sha512-lCr8OHhiWCTw4v8POJovCoh4T7I9U11yVsPjMWWnnMmp9ZowCxyad1Pathle/9HjaDp+fdQKjO9fQydE6RHTZg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
+      "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
       "requires": {
         "source-map": "~0.6.0"
       }
@@ -3698,9 +5326,9 @@
       "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="
     },
     "cli-table3": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
-      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
+      "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
       "requires": {
         "@colors/colors": "1.5.0",
         "string-width": "^4.2.0"
@@ -3765,9 +5393,9 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "colord": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
-      "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ=="
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="
     },
     "colorette": {
       "version": "2.0.19",
@@ -3871,9 +5499,9 @@
       "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA=="
     },
     "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
     },
     "convert-source-map": {
       "version": "1.8.0",
@@ -3912,9 +5540,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -3939,9 +5567,9 @@
           }
         },
         "globby": {
-          "version": "13.1.2",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
-          "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+          "version": "13.1.3",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+          "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
           "requires": {
             "dir-glob": "^3.0.1",
             "fast-glob": "^3.2.11",
@@ -3974,9 +5602,9 @@
       }
     },
     "core-js": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.24.1.tgz",
-      "integrity": "sha512-0QTBSYSUZ6Gq21utGzkfITDylE8jWC9Ne1D2MrhvlsZBI1x39OdDIVbzSqtgMndIy6BlHxBXpMGqzZmnztg2rg=="
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
+      "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w=="
     },
     "core-js-compat": {
       "version": "3.23.5",
@@ -4040,42 +5668,54 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
     "css-declaration-sorter": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.0.tgz",
-      "integrity": "sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og=="
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
+      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w=="
     },
     "css-loader": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
-      "integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.3.tgz",
+      "integrity": "sha512-qhOH1KlBMnZP8FzRO6YCH9UHXQhVMcEGLyNdb7Hv2cpcmJbW0YrddO+tG1ab5nT41KpHIYGsbeHqxB9xPu1pKQ==",
       "requires": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.7",
+        "postcss": "^8.4.19",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.0",
         "postcss-modules-scope": "^3.0.0",
         "postcss-modules-values": "^4.0.0",
         "postcss-value-parser": "^4.2.0",
-        "semver": "^7.3.5"
+        "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "8.4.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+          "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+          "requires": {
+            "nanoid": "^3.3.4",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.2"
+          }
+        }
       }
     },
     "css-minimizer-webpack-plugin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-4.0.0.tgz",
-      "integrity": "sha512-7ZXXRzRHvofv3Uac5Y+RkWRNo0ZMlcg8e9/OtrqUYmwDWJo+qs67GvdeFrXLsFb7czKNwjQhPkM0avlIYl+1nA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-4.2.2.tgz",
+      "integrity": "sha512-s3Of/4jKfw1Hj9CxEO1E5oXhQAxlayuHO2y/ML+C6I9sQ7FdzfEV6QgMLN3vI+qFsjJGIAFLKtQK7t8BOXAIyA==",
       "requires": {
         "cssnano": "^5.1.8",
-        "jest-worker": "^27.5.1",
-        "postcss": "^8.4.13",
+        "jest-worker": "^29.1.2",
+        "postcss": "^8.4.17",
         "schema-utils": "^4.0.0",
         "serialize-javascript": "^6.0.0",
         "source-map": "^0.6.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -4091,10 +5731,36 @@
             "fast-deep-equal": "^3.1.3"
           }
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "jest-worker": {
+          "version": "29.4.1",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.1.tgz",
+          "integrity": "sha512-O9doU/S1EBe+yp/mstQ0VpPwpv0Clgn68TkNwGxL6/usX/KUW9Arnn4ag8C3jc6qHcXznhsT5Na1liYzAsuAbQ==",
+          "requires": {
+            "@types/node": "*",
+            "jest-util": "^29.4.1",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^8.0.0"
+          }
+        },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "postcss": {
+          "version": "8.4.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+          "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+          "requires": {
+            "nanoid": "^3.3.4",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.2"
+          }
         },
         "schema-utils": {
           "version": "4.0.0",
@@ -4105,6 +5771,14 @@
             "ajv": "^8.8.0",
             "ajv-formats": "^2.1.1",
             "ajv-keywords": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -4141,22 +5815,22 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "cssnano": {
-      "version": "5.1.12",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.12.tgz",
-      "integrity": "sha512-TgvArbEZu0lk/dvg2ja+B7kYoD7BBCmn3+k58xD0qjrGHsFzXY/wKTo9M5egcUCabPol05e/PVoIu79s2JN4WQ==",
+      "version": "5.1.14",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.14.tgz",
+      "integrity": "sha512-Oou7ihiTocbKqi0J1bB+TRJIQX5RMR3JghA8hcWSw9mjBLQ5Y3RWqEDoYG3sRNlAbCIXpqMoZGbq5KDR3vdzgw==",
       "requires": {
-        "cssnano-preset-default": "^5.2.12",
+        "cssnano-preset-default": "^5.2.13",
         "lilconfig": "^2.0.3",
         "yaml": "^1.10.2"
       }
     },
     "cssnano-preset-advanced": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.8.tgz",
-      "integrity": "sha512-xUlLLnEB1LjpEik+zgRNlk8Y/koBPPtONZjp7JKbXigeAmCrFvq9H0pXW5jJV45bQWAlmJ0sKy+IMr0XxLYQZg==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.9.tgz",
+      "integrity": "sha512-njnh4pp1xCsibJcEHnWZb4EEzni0ePMqPuPNyuWT4Z+YeXmsgqNuTPIljXFEXhxGsWs9183JkXgHxc1TcsahIg==",
       "requires": {
-        "autoprefixer": "^10.3.7",
-        "cssnano-preset-default": "^5.2.12",
+        "autoprefixer": "^10.4.12",
+        "cssnano-preset-default": "^5.2.13",
         "postcss-discard-unused": "^5.1.0",
         "postcss-merge-idents": "^5.1.1",
         "postcss-reduce-idents": "^5.2.0",
@@ -4164,24 +5838,24 @@
       }
     },
     "cssnano-preset-default": {
-      "version": "5.2.12",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.12.tgz",
-      "integrity": "sha512-OyCBTZi+PXgylz9HAA5kHyoYhfGcYdwFmyaJzWnzxuGRtnMw/kR6ilW9XzlzlRAtB6PLT/r+prYgkef7hngFew==",
+      "version": "5.2.13",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.13.tgz",
+      "integrity": "sha512-PX7sQ4Pb+UtOWuz8A1d+Rbi+WimBIxJTRyBdgGp1J75VU0r/HFQeLnMYgHiCAp6AR4rqrc7Y4R+1Rjk3KJz6DQ==",
       "requires": {
-        "css-declaration-sorter": "^6.3.0",
+        "css-declaration-sorter": "^6.3.1",
         "cssnano-utils": "^3.1.0",
         "postcss-calc": "^8.2.3",
         "postcss-colormin": "^5.3.0",
-        "postcss-convert-values": "^5.1.2",
+        "postcss-convert-values": "^5.1.3",
         "postcss-discard-comments": "^5.1.2",
         "postcss-discard-duplicates": "^5.1.0",
         "postcss-discard-empty": "^5.1.1",
         "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.6",
-        "postcss-merge-rules": "^5.1.2",
+        "postcss-merge-longhand": "^5.1.7",
+        "postcss-merge-rules": "^5.1.3",
         "postcss-minify-font-values": "^5.1.0",
         "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.3",
+        "postcss-minify-params": "^5.1.4",
         "postcss-minify-selectors": "^5.2.1",
         "postcss-normalize-charset": "^5.1.0",
         "postcss-normalize-display-values": "^5.1.0",
@@ -4189,11 +5863,11 @@
         "postcss-normalize-repeat-style": "^5.1.1",
         "postcss-normalize-string": "^5.1.0",
         "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.1",
         "postcss-normalize-url": "^5.1.0",
         "postcss-normalize-whitespace": "^5.1.1",
         "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.0",
+        "postcss-reduce-initial": "^5.1.1",
         "postcss-reduce-transforms": "^5.1.0",
         "postcss-svgo": "^5.1.0",
         "postcss-unique-selectors": "^5.1.1"
@@ -4320,27 +5994,12 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "detect-port": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
-      "integrity": "sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
+      "integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
       "requires": {
         "address": "^1.0.1",
-        "debug": "^2.6.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        }
+        "debug": "4"
       }
     },
     "dir-glob": {
@@ -5158,13 +6817,13 @@
       }
     },
     "express": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.0",
+        "body-parser": "1.20.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.5.0",
@@ -5183,7 +6842,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.18.0",
@@ -5450,9 +7109,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.2",
@@ -5697,9 +7356,9 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "global-dirs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
       "requires": {
         "ini": "2.0.0"
       },
@@ -6059,9 +7718,9 @@
       }
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-deceiver": {
       "version": "1.2.7",
@@ -6146,9 +7805,9 @@
       }
     },
     "immer": {
-      "version": "9.0.15",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
-      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ=="
+      "version": "9.0.19",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.19.tgz",
+      "integrity": "sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -6295,6 +7954,13 @@
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "requires": {
         "ci-info": "^2.0.0"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+        }
       }
     },
     "is-core-module": {
@@ -6518,6 +8184,64 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
     },
+    "jest-util": {
+      "version": "29.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.1.tgz",
+      "integrity": "sha512-bQy9FPGxVutgpN4VRc0hk6w7Hx/m6L53QxpDreTZgJd9gfx/AV2MjyPde9tGyZRINAUrSv57p2inGBu2dRLmkQ==",
+      "requires": {
+        "@jest/types": "^29.4.1",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -6644,9 +8368,9 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
     "klona": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
-      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="
     },
     "language-subtag-registry": {
       "version": "0.3.22",
@@ -6866,9 +8590,9 @@
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
     },
     "memfs": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.7.tgz",
-      "integrity": "sha512-ygaiUSNalBX85388uskeCyhSAoOSgzBbtVCr9jA2RROssFL9Q19/ZXFqS+2Th2sr1ewNIWgFdLzLC3Yl1Zv+lw==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.13.tgz",
+      "integrity": "sha512-omTM41g3Skpvx5dSYeZIbXKcXoAVc/AoMNwn9TKx++L/gaen/+4TTttmu8ZSch5vfVJ8uJvGbroTsIlslRg6lg==",
       "requires": {
         "fs-monkey": "^1.0.3"
       }
@@ -6940,17 +8664,17 @@
       }
     },
     "mini-css-extract-plugin": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz",
-      "integrity": "sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.2.tgz",
+      "integrity": "sha512-EdlUizq13o0Pd+uCp+WO/JpkLvHRVGt97RqfeGhXqAcorYo1ypJSpkV+WDT0vY/kmh/p7wRdJNJtuyK540PXDw==",
       "requires": {
         "schema-utils": "^4.0.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -7587,12 +9311,49 @@
       }
     },
     "postcss-convert-values": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.2.tgz",
-      "integrity": "sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
+      "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
       "requires": {
-        "browserslist": "^4.20.3",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.21.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+          "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001449",
+            "electron-to-chromium": "^1.4.284",
+            "node-releases": "^2.0.8",
+            "update-browserslist-db": "^1.0.10"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001450",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz",
+          "integrity": "sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew=="
+        },
+        "electron-to-chromium": {
+          "version": "1.4.286",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.286.tgz",
+          "integrity": "sha512-Vp3CVhmYpgf4iXNKAucoQUDcCrBQX3XLBtwgFqP9BUXuucgvAV9zWp1kYU7LL9j4++s9O+12cb3wMtN4SJy6UQ=="
+        },
+        "node-releases": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.9.tgz",
+          "integrity": "sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA=="
+        },
+        "update-browserslist-db": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+          "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+          "requires": {
+            "escalade": "^3.1.1",
+            "picocolors": "^1.0.0"
+          }
+        }
       }
     },
     "postcss-discard-comments": {
@@ -7624,13 +9385,13 @@
       }
     },
     "postcss-loader": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-7.0.1.tgz",
-      "integrity": "sha512-VRviFEyYlLjctSM93gAZtcJJ/iSkPZ79zWbN/1fSH+NisBByEiVLqpdVDrPLVSi8DX0oJo12kL/GppTBdKVXiQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-7.0.2.tgz",
+      "integrity": "sha512-fUJzV/QH7NXUAqV8dWJ9Lg4aTkDCezpTS5HgJ2DvqznexTbSTxgi/dTECvTZ15BwKTtk8G/bqI/QTu2HPd3ZCg==",
       "requires": {
         "cosmiconfig": "^7.0.0",
         "klona": "^2.0.5",
-        "semver": "^7.3.7"
+        "semver": "^7.3.8"
       }
     },
     "postcss-merge-idents": {
@@ -7643,23 +9404,60 @@
       }
     },
     "postcss-merge-longhand": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.6.tgz",
-      "integrity": "sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
+      "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
       "requires": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.0"
+        "stylehacks": "^5.1.1"
       }
     },
     "postcss-merge-rules": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.2.tgz",
-      "integrity": "sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.3.tgz",
+      "integrity": "sha512-LbLd7uFC00vpOuMvyZop8+vvhnfRGpp2S+IMQKeuOZZapPRY4SMq5ErjQeHbHsjCUgJkRNrlU+LmxsKIqPKQlA==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
         "cssnano-utils": "^3.1.0",
         "postcss-selector-parser": "^6.0.5"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.21.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+          "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001449",
+            "electron-to-chromium": "^1.4.284",
+            "node-releases": "^2.0.8",
+            "update-browserslist-db": "^1.0.10"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001450",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz",
+          "integrity": "sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew=="
+        },
+        "electron-to-chromium": {
+          "version": "1.4.286",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.286.tgz",
+          "integrity": "sha512-Vp3CVhmYpgf4iXNKAucoQUDcCrBQX3XLBtwgFqP9BUXuucgvAV9zWp1kYU7LL9j4++s9O+12cb3wMtN4SJy6UQ=="
+        },
+        "node-releases": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.9.tgz",
+          "integrity": "sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA=="
+        },
+        "update-browserslist-db": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+          "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+          "requires": {
+            "escalade": "^3.1.1",
+            "picocolors": "^1.0.0"
+          }
+        }
       }
     },
     "postcss-minify-font-values": {
@@ -7681,13 +9479,50 @@
       }
     },
     "postcss-minify-params": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.3.tgz",
-      "integrity": "sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
+      "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.21.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+          "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001449",
+            "electron-to-chromium": "^1.4.284",
+            "node-releases": "^2.0.8",
+            "update-browserslist-db": "^1.0.10"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001450",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz",
+          "integrity": "sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew=="
+        },
+        "electron-to-chromium": {
+          "version": "1.4.286",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.286.tgz",
+          "integrity": "sha512-Vp3CVhmYpgf4iXNKAucoQUDcCrBQX3XLBtwgFqP9BUXuucgvAV9zWp1kYU7LL9j4++s9O+12cb3wMtN4SJy6UQ=="
+        },
+        "node-releases": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.9.tgz",
+          "integrity": "sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA=="
+        },
+        "update-browserslist-db": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+          "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+          "requires": {
+            "escalade": "^3.1.1",
+            "picocolors": "^1.0.0"
+          }
+        }
       }
     },
     "postcss-minify-selectors": {
@@ -7775,12 +9610,49 @@
       }
     },
     "postcss-normalize-unicode": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
-      "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
+      "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.21.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+          "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001449",
+            "electron-to-chromium": "^1.4.284",
+            "node-releases": "^2.0.8",
+            "update-browserslist-db": "^1.0.10"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001450",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz",
+          "integrity": "sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew=="
+        },
+        "electron-to-chromium": {
+          "version": "1.4.286",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.286.tgz",
+          "integrity": "sha512-Vp3CVhmYpgf4iXNKAucoQUDcCrBQX3XLBtwgFqP9BUXuucgvAV9zWp1kYU7LL9j4++s9O+12cb3wMtN4SJy6UQ=="
+        },
+        "node-releases": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.9.tgz",
+          "integrity": "sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA=="
+        },
+        "update-browserslist-db": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+          "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+          "requires": {
+            "escalade": "^3.1.1",
+            "picocolors": "^1.0.0"
+          }
+        }
       }
     },
     "postcss-normalize-url": {
@@ -7818,12 +9690,49 @@
       }
     },
     "postcss-reduce-initial": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
-      "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.1.tgz",
+      "integrity": "sha512-//jeDqWcHPuXGZLoolFrUXBDyuEGbr9S2rMo19bkTIjBQ4PqkaO+oI8wua5BOUxpfi97i3PCoInsiFIEBfkm9w==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.21.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+          "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001449",
+            "electron-to-chromium": "^1.4.284",
+            "node-releases": "^2.0.8",
+            "update-browserslist-db": "^1.0.10"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001450",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz",
+          "integrity": "sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew=="
+        },
+        "electron-to-chromium": {
+          "version": "1.4.286",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.286.tgz",
+          "integrity": "sha512-Vp3CVhmYpgf4iXNKAucoQUDcCrBQX3XLBtwgFqP9BUXuucgvAV9zWp1kYU7LL9j4++s9O+12cb3wMtN4SJy6UQ=="
+        },
+        "node-releases": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.9.tgz",
+          "integrity": "sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA=="
+        },
+        "update-browserslist-db": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+          "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+          "requires": {
+            "escalade": "^3.1.1",
+            "picocolors": "^1.0.0"
+          }
+        }
       }
     },
     "postcss-reduce-transforms": {
@@ -7835,20 +9744,20 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
-      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
       }
     },
     "postcss-sort-media-queries": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.2.1.tgz",
-      "integrity": "sha512-9VYekQalFZ3sdgcTjXMa0dDjsfBVHXlraYJEMiOJ/2iMmI2JGCMavP16z3kWOaRu8NSaJCTgVpB/IVpH5yT9YQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.3.0.tgz",
+      "integrity": "sha512-jAl8gJM2DvuIJiI9sL1CuiHtKM4s5aEIomkU8G3LFvbP+p8i7Sz8VV63uieTgoewGqKbi+hxBTiOKJlB35upCg==",
       "requires": {
-        "sort-css-media-queries": "2.0.4"
+        "sort-css-media-queries": "2.1.0"
       }
     },
     "postcss-svgo": {
@@ -8003,9 +9912,9 @@
       "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
     },
     "qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "requires": {
         "side-channel": "^1.0.4"
       }
@@ -8190,9 +10099,9 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "loader-utils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
-          "integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ=="
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+          "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw=="
         },
         "locate-path": {
           "version": "6.0.0",
@@ -8383,21 +10292,11 @@
       }
     },
     "recursive-readdir": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
-      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
       "requires": {
-        "minimatch": "3.0.4"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
+        "minimatch": "^3.0.5"
       }
     },
     "regenerate": {
@@ -8759,9 +10658,9 @@
       }
     },
     "rxjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
-      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -8814,17 +10713,17 @@
       "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg=="
     },
     "selfsigned": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.1.tgz",
-      "integrity": "sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
+      "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
       "requires": {
         "node-forge": "^1"
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -8900,15 +10799,15 @@
       }
     },
     "serve-handler": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
-      "integrity": "sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
+      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
       "requires": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
         "fast-url-parser": "1.1.3",
         "mime-types": "2.1.18",
-        "minimatch": "3.0.4",
+        "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
         "path-to-regexp": "2.2.1",
         "range-parser": "1.2.0"
@@ -8925,14 +10824,6 @@
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "requires": {
             "mime-db": "~1.33.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
           }
         },
         "path-to-regexp": {
@@ -9050,9 +10941,9 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.0.tgz",
+      "integrity": "sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ=="
     },
     "shelljs": {
       "version": "0.8.5",
@@ -9128,9 +11019,9 @@
       }
     },
     "sort-css-media-queries": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.0.4.tgz",
-      "integrity": "sha512-PAIsEK/XupCQwitjv7XxoMvYhT7EAfyzI3hsy/MyDgTvc+Ft55ctdkctJLOy6cQejaIC+zjpUL4djFVm2ivOOw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.1.0.tgz",
+      "integrity": "sha512-IeWvo8NkNiY2vVYdPa27MCQiR0MN0M80johAYFVxWWXQ44KU84WNxjslwBHmc/7ZL2ccwkM7/e6S5aiKZXm7jA=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -9202,9 +11093,9 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
     "std-env": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.1.1.tgz",
-      "integrity": "sha512-/c645XdExBypL01TpFKiG/3RAa/Qmu+zRi0MwAmrdEkwHNuN0ebo8ccAXBBDa5Z0QOJgBskUIbuCK91x0sCVEw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.2.tgz",
+      "integrity": "sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA=="
     },
     "string-width": {
       "version": "5.1.2",
@@ -9357,12 +11248,49 @@
       }
     },
     "stylehacks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
-      "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
+      "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-selector-parser": "^6.0.4"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.21.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+          "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001449",
+            "electron-to-chromium": "^1.4.284",
+            "node-releases": "^2.0.8",
+            "update-browserslist-db": "^1.0.10"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001450",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz",
+          "integrity": "sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew=="
+        },
+        "electron-to-chromium": {
+          "version": "1.4.286",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.286.tgz",
+          "integrity": "sha512-Vp3CVhmYpgf4iXNKAucoQUDcCrBQX3XLBtwgFqP9BUXuucgvAV9zWp1kYU7LL9j4++s9O+12cb3wMtN4SJy6UQ=="
+        },
+        "node-releases": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.9.tgz",
+          "integrity": "sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA=="
+        },
+        "update-browserslist-db": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+          "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+          "requires": {
+            "escalade": "^3.1.1",
+            "picocolors": "^1.0.0"
+          }
+        }
       }
     },
     "supports-color": {
@@ -9545,9 +11473,9 @@
       }
     },
     "type-fest": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
-      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw=="
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -10032,9 +11960,9 @@
       }
     },
     "webpack-bundle-analyzer": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.5.0.tgz",
-      "integrity": "sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.7.0.tgz",
+      "integrity": "sha512-j9b8ynpJS4K+zfO5GGwsAcQX4ZHpWV+yRiHDiL+bE0XHJ8NiPYLTNVQdlFYWxtpg9lfAQNlwJg16J9AJtFSXRg==",
       "requires": {
         "acorn": "^8.0.4",
         "acorn-walk": "^8.0.0",
@@ -10110,9 +12038,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -10152,9 +12080,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.9.3.tgz",
-      "integrity": "sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.11.1.tgz",
+      "integrity": "sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==",
       "requires": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -10179,7 +12107,7 @@
         "p-retry": "^4.5.0",
         "rimraf": "^3.0.2",
         "schema-utils": "^4.0.0",
-        "selfsigned": "^2.0.1",
+        "selfsigned": "^2.1.1",
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
@@ -10188,9 +12116,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -10223,9 +12151,9 @@
           }
         },
         "ws": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-          "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA=="
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+          "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig=="
         }
       }
     },
@@ -10364,9 +12292,9 @@
       "dev": true
     },
     "wrap-ansi": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.0.1.tgz",
-      "integrity": "sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "requires": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -10379,9 +12307,9 @@
           "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
         },
         "ansi-styles": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.0.tgz",
-          "integrity": "sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ=="
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
         },
         "strip-ansi": {
           "version": "7.0.1",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5669,9 +5669,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4894,45 +4894,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
-    "body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "requires": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        }
-      }
-    },
     "bonjour-service": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.0.tgz",
@@ -5088,6 +5049,60 @@
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+        }
+      }
+    },
+    "call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+        },
+        "get-intrinsic": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+          "requires": {
+            "call-bind-apply-helpers": "^1.0.1",
+            "es-define-property": "^1.0.1",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.0.0",
+            "function-bind": "^1.1.2",
+            "get-proto": "^1.0.0",
+            "gopd": "^1.2.0",
+            "has-symbols": "^1.1.0",
+            "hasown": "^2.0.2",
+            "math-intrinsics": "^1.1.0"
+          }
+        },
+        "has-symbols": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+        }
       }
     },
     "callsites": {
@@ -5516,11 +5531,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -6103,6 +6113,16 @@
         }
       }
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -6142,11 +6162,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-3.2.0.tgz",
       "integrity": "sha512-SNujglcLTTg+lDAcApPNgEdudaqQFiAbJCqzjNxJkvN9vAwCGi0uu8IUVvx+f16h+V44KCY6Y2yboroc9pilHg=="
-    },
-    "encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -6223,10 +6238,28 @@
         }
       }
     },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
     "es-module-lexer": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+    },
+    "es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
     },
     "es-shim-unscopables": {
       "version": "1.0.0",
@@ -6824,36 +6857,36 @@
       }
     },
     "express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -6866,6 +6899,30 @@
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
         },
+        "body-parser": {
+          "version": "1.20.3",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+          "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+          "requires": {
+            "bytes": "3.1.2",
+            "content-type": "~1.0.5",
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "destroy": "1.2.0",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "on-finished": "2.4.1",
+            "qs": "6.13.0",
+            "raw-body": "2.5.2",
+            "type-is": "~1.6.18",
+            "unpipe": "1.0.0"
+          }
+        },
+        "bytes": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+        },
         "content-disposition": {
           "version": "0.5.4",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -6873,6 +6930,11 @@
           "requires": {
             "safe-buffer": "5.2.1"
           }
+        },
+        "cookie": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+          "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="
         },
         "debug": {
           "version": "2.6.9",
@@ -6882,25 +6944,128 @@
             "ms": "2.0.0"
           }
         },
+        "encodeurl": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+          "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
+        },
+        "finalhandler": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+          "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~2.0.0",
+            "escape-html": "~1.0.3",
+            "on-finished": "2.4.1",
+            "parseurl": "~1.3.3",
+            "statuses": "2.0.1",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "merge-descriptors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+          "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
+        "object-inspect": {
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+          "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA=="
+        },
         "path-to-regexp": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-          "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+          "version": "0.1.12",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+          "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+        },
+        "qs": {
+          "version": "6.13.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+          "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+          "requires": {
+            "side-channel": "^1.0.6"
+          }
         },
         "range-parser": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
         },
+        "raw-body": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+          "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+          "requires": {
+            "bytes": "3.1.2",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
+        },
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "send": {
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+          "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "destroy": "1.2.0",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "2.0.0",
+            "mime": "1.6.0",
+            "ms": "2.1.3",
+            "on-finished": "2.4.1",
+            "range-parser": "~1.2.1",
+            "statuses": "2.0.1"
+          },
+          "dependencies": {
+            "encodeurl": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+              "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+            },
+            "ms": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.16.2",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+          "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+          "requires": {
+            "encodeurl": "~2.0.0",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.3",
+            "send": "0.19.0"
+          }
+        },
+        "side-channel": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+          "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+          "requires": {
+            "es-errors": "^1.3.0",
+            "object-inspect": "^1.13.3",
+            "side-channel-list": "^1.0.0",
+            "side-channel-map": "^1.0.1",
+            "side-channel-weakmap": "^1.0.2"
+          }
         }
       }
     },
@@ -7040,35 +7205,6 @@
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "requires": {
         "to-regex-range": "^5.0.1"
-      }
-    },
-    "finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
-      "requires": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        }
       }
     },
     "find-cache-dir": {
@@ -7307,6 +7443,15 @@
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
     },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -7416,6 +7561,11 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
+    },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
     },
     "got": {
       "version": "9.6.0",
@@ -7527,6 +7677,21 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
+    },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      },
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+        }
+      }
     },
     "hast-to-hyperscript": {
       "version": "9.0.1",
@@ -8545,6 +8710,11 @@
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
     },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
     "mdast-squeeze-paragraphs": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-4.0.0.tgz",
@@ -8603,11 +8773,6 @@
       "requires": {
         "fs-monkey": "^1.0.3"
       }
-    },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -8852,7 +9017,8 @@
     "object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
@@ -9918,14 +10084,6 @@
       "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
       "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
     },
-    "qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "requires": {
-        "side-channel": "^1.0.4"
-      }
-    },
     "queue": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
@@ -9951,24 +10109,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A=="
-    },
-    "raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "requires": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-        }
-      }
     },
     "rc": {
       "version": "1.2.8",
@@ -10750,53 +10890,6 @@
         }
       }
     },
-    "send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-      "requires": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-            }
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "range-parser": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-        }
-      }
-    },
     "serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -10900,17 +10993,6 @@
         }
       }
     },
-    "serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
-      "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.18.0"
-      }
-    },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -10966,10 +11048,118 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
+      }
+    },
+    "side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "dependencies": {
+        "object-inspect": {
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+          "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA=="
+        }
+      }
+    },
+    "side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+        },
+        "get-intrinsic": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+          "requires": {
+            "call-bind-apply-helpers": "^1.0.1",
+            "es-define-property": "^1.0.1",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.0.0",
+            "function-bind": "^1.1.2",
+            "get-proto": "^1.0.0",
+            "gopd": "^1.2.0",
+            "has-symbols": "^1.1.0",
+            "hasown": "^2.0.2",
+            "math-intrinsics": "^1.1.0"
+          }
+        },
+        "has-symbols": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+        },
+        "object-inspect": {
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+          "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA=="
+        }
+      }
+    },
+    "side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+        },
+        "get-intrinsic": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+          "requires": {
+            "call-bind-apply-helpers": "^1.0.1",
+            "es-define-property": "^1.0.1",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.0.0",
+            "function-bind": "^1.1.2",
+            "get-proto": "^1.0.0",
+            "gopd": "^1.2.0",
+            "has-symbols": "^1.1.0",
+            "hasown": "^2.0.2",
+            "math-intrinsics": "^1.1.0"
+          }
+        },
+        "has-symbols": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+        },
+        "object-inspect": {
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+          "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA=="
+        }
       }
     },
     "signal-exit": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8498,9 +8498,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -11645,9 +11645,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8782,9 +8782,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10001,9 +10001,9 @@
       }
     },
     "react-bootstrap-icons": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/react-bootstrap-icons/-/react-bootstrap-icons-1.8.4.tgz",
-      "integrity": "sha512-PTCQqTLn0AdCy622reNmV+b4PwCPIOA0PFYT3CSfiqw5nwDPGntOm3Pr+ZsMxXD655QAs1nrMm7u0t3+HVxhtQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-icons/-/react-bootstrap-icons-1.10.2.tgz",
+      "integrity": "sha512-PC72g6uARdSxZH+ViBbul3FRWKuIhiJajahwt1h0daPBDw789KqpA+x3hrJpSUyQMF0PQ9LfWxu1a0O67bqPeg==",
       "requires": {
         "prop-types": "^15.7.2"
       }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4048,15 +4048,6 @@
         "@types/json-schema": "*"
       }
     },
-    "@types/eslint-scope": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
-      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
-      "requires": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "@types/estree": {
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
@@ -4292,137 +4283,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
     },
-    "@webassemblyjs/ast": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
-      "requires": {
-        "@webassemblyjs/helper-numbers": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
-      }
-    },
-    "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ=="
-    },
-    "@webassemblyjs/helper-api-error": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg=="
-    },
-    "@webassemblyjs/helper-buffer": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA=="
-    },
-    "@webassemblyjs/helper-numbers": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
-      "requires": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.1",
-        "@webassemblyjs/helper-api-error": "1.11.1",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q=="
-    },
-    "@webassemblyjs/helper-wasm-section": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
-      "requires": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-buffer": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/wasm-gen": "1.11.1"
-      }
-    },
-    "@webassemblyjs/ieee754": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
-      "requires": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "@webassemblyjs/leb128": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
-      "requires": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webassemblyjs/utf8": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ=="
-    },
-    "@webassemblyjs/wasm-edit": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
-      "requires": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-buffer": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/helper-wasm-section": "1.11.1",
-        "@webassemblyjs/wasm-gen": "1.11.1",
-        "@webassemblyjs/wasm-opt": "1.11.1",
-        "@webassemblyjs/wasm-parser": "1.11.1",
-        "@webassemblyjs/wast-printer": "1.11.1"
-      }
-    },
-    "@webassemblyjs/wasm-gen": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
-      "requires": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/ieee754": "1.11.1",
-        "@webassemblyjs/leb128": "1.11.1",
-        "@webassemblyjs/utf8": "1.11.1"
-      }
-    },
-    "@webassemblyjs/wasm-opt": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
-      "requires": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-buffer": "1.11.1",
-        "@webassemblyjs/wasm-gen": "1.11.1",
-        "@webassemblyjs/wasm-parser": "1.11.1"
-      }
-    },
-    "@webassemblyjs/wasm-parser": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
-      "requires": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-api-error": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/ieee754": "1.11.1",
-        "@webassemblyjs/leb128": "1.11.1",
-        "@webassemblyjs/utf8": "1.11.1"
-      }
-    },
-    "@webassemblyjs/wast-printer": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
-      "requires": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@xtuc/long": "4.2.2"
-      }
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -4446,11 +4306,6 @@
       "version": "8.7.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
       "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
-    },
-    "acorn-import-assertions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -6171,15 +6026,6 @@
         "once": "^1.4.0"
       }
     },
-    "enhanced-resolve": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
-      "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
-      "requires": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
-      }
-    },
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -6247,11 +6093,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-    },
-    "es-module-lexer": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
     },
     "es-object-atoms": {
       "version": "1.0.0",
@@ -7109,6 +6950,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "fast-uri": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.4.tgz",
+      "integrity": "sha512-G3iTQw1DizJQ5eEqj1CbFCWhq+pzum7qepkxU7rS1FGZDqjYKcrguo9XDRbV7EgPnn8CgaPigTq+NEjyioeYZQ=="
     },
     "fast-url-parser": {
       "version": "1.1.3",
@@ -12092,15 +11938,6 @@
         "rxjs": "^7.5.4"
       }
     },
-    "watchpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
-      "requires": {
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.1.2"
-      }
-    },
     "wbuf": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
@@ -12120,34 +11957,374 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "webpack": {
-      "version": "5.73.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
-      "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "requires": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^0.0.51",
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/wasm-edit": "1.11.1",
-        "@webassemblyjs/wasm-parser": "1.11.1",
-        "acorn": "^8.4.1",
-        "acorn-import-assertions": "^1.7.6",
-        "browserslist": "^4.14.5",
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.3",
-        "es-module-lexer": "^0.9.0",
+        "enhanced-resolve": "^5.17.1",
+        "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
+        "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.1.0",
+        "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.3.1",
+        "terser-webpack-plugin": "^5.3.10",
+        "watchpack": "^2.4.1",
         "webpack-sources": "^3.2.3"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+          "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+          "requires": {
+            "@jridgewell/set-array": "^1.2.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.24"
+          }
+        },
+        "@jridgewell/set-array": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+          "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="
+        },
+        "@jridgewell/source-map": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+          "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+          "requires": {
+            "@jridgewell/gen-mapping": "^0.3.5",
+            "@jridgewell/trace-mapping": "^0.3.25"
+          }
+        },
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.25",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+          "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.1.0",
+            "@jridgewell/sourcemap-codec": "^1.4.14"
+          }
+        },
+        "@types/eslint-scope": {
+          "version": "3.7.7",
+          "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+          "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+          "requires": {
+            "@types/eslint": "*",
+            "@types/estree": "*"
+          }
+        },
+        "@types/estree": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+          "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+        },
+        "@webassemblyjs/ast": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+          "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+          "requires": {
+            "@webassemblyjs/helper-numbers": "1.13.2",
+            "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+          }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+          "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA=="
+        },
+        "@webassemblyjs/helper-api-error": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+          "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ=="
+        },
+        "@webassemblyjs/helper-buffer": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+          "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA=="
+        },
+        "@webassemblyjs/helper-numbers": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+          "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+          "requires": {
+            "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+            "@webassemblyjs/helper-api-error": "1.13.2",
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+          "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA=="
+        },
+        "@webassemblyjs/helper-wasm-section": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+          "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+          "requires": {
+            "@webassemblyjs/ast": "1.14.1",
+            "@webassemblyjs/helper-buffer": "1.14.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+            "@webassemblyjs/wasm-gen": "1.14.1"
+          }
+        },
+        "@webassemblyjs/ieee754": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+          "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+          "requires": {
+            "@xtuc/ieee754": "^1.2.0"
+          }
+        },
+        "@webassemblyjs/leb128": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+          "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+          "requires": {
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "@webassemblyjs/utf8": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+          "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ=="
+        },
+        "@webassemblyjs/wasm-edit": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+          "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+          "requires": {
+            "@webassemblyjs/ast": "1.14.1",
+            "@webassemblyjs/helper-buffer": "1.14.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+            "@webassemblyjs/helper-wasm-section": "1.14.1",
+            "@webassemblyjs/wasm-gen": "1.14.1",
+            "@webassemblyjs/wasm-opt": "1.14.1",
+            "@webassemblyjs/wasm-parser": "1.14.1",
+            "@webassemblyjs/wast-printer": "1.14.1"
+          }
+        },
+        "@webassemblyjs/wasm-gen": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+          "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+          "requires": {
+            "@webassemblyjs/ast": "1.14.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+            "@webassemblyjs/ieee754": "1.13.2",
+            "@webassemblyjs/leb128": "1.13.2",
+            "@webassemblyjs/utf8": "1.13.2"
+          }
+        },
+        "@webassemblyjs/wasm-opt": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+          "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+          "requires": {
+            "@webassemblyjs/ast": "1.14.1",
+            "@webassemblyjs/helper-buffer": "1.14.1",
+            "@webassemblyjs/wasm-gen": "1.14.1",
+            "@webassemblyjs/wasm-parser": "1.14.1"
+          }
+        },
+        "@webassemblyjs/wasm-parser": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+          "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+          "requires": {
+            "@webassemblyjs/ast": "1.14.1",
+            "@webassemblyjs/helper-api-error": "1.13.2",
+            "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+            "@webassemblyjs/ieee754": "1.13.2",
+            "@webassemblyjs/leb128": "1.13.2",
+            "@webassemblyjs/utf8": "1.13.2"
+          }
+        },
+        "@webassemblyjs/wast-printer": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+          "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+          "requires": {
+            "@webassemblyjs/ast": "1.14.1",
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "acorn": {
+          "version": "8.14.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+          "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="
+        },
+        "browserslist": {
+          "version": "4.24.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
+          "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001688",
+            "electron-to-chromium": "^1.5.73",
+            "node-releases": "^2.0.19",
+            "update-browserslist-db": "^1.1.1"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001690",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+          "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w=="
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "electron-to-chromium": {
+          "version": "1.5.76",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
+          "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ=="
+        },
+        "enhanced-resolve": {
+          "version": "5.18.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
+          "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
+          "requires": {
+            "graceful-fs": "^4.2.4",
+            "tapable": "^2.2.0"
+          }
+        },
+        "es-module-lexer": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+          "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ=="
+        },
+        "escalade": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+          "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
+        },
+        "graceful-fs": {
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+          "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "node-releases": {
+          "version": "2.0.19",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+          "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
+        },
+        "picocolors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+          "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+        },
+        "schema-utils": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        },
+        "serialize-javascript": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+          "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "terser": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
+          "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+          "requires": {
+            "@jridgewell/source-map": "^0.3.3",
+            "acorn": "^8.8.2",
+            "commander": "^2.20.0",
+            "source-map-support": "~0.5.20"
+          }
+        },
+        "terser-webpack-plugin": {
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz",
+          "integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
+          "requires": {
+            "@jridgewell/trace-mapping": "^0.3.25",
+            "jest-worker": "^27.4.5",
+            "schema-utils": "^4.3.0",
+            "serialize-javascript": "^6.0.2",
+            "terser": "^5.31.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "8.17.1",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+              "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+              "requires": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+              }
+            },
+            "ajv-keywords": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+              "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+              "requires": {
+                "fast-deep-equal": "^3.1.3"
+              }
+            },
+            "schema-utils": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+              "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+              "requires": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+              }
+            }
+          }
+        },
+        "update-browserslist-db": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+          "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+          "requires": {
+            "escalade": "^3.2.0",
+            "picocolors": "^1.1.0"
+          }
+        },
+        "watchpack": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+          "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+          "requires": {
+            "glob-to-regexp": "^0.4.1",
+            "graceful-fs": "^4.1.2"
+          }
+        }
       }
     },
     "webpack-bundle-analyzer": {

--- a/website/package.json
+++ b/website/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "devDependencies": {
-    "eslint": "^8.21.0",
+    "eslint": "^8.35.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "react": "^18.1.0",
-    "react-bootstrap-icons": "^1.8.4",
+    "react-bootstrap-icons": "^1.10.2",
     "react-dom": "^18.1.0"
   },
   "browserslist": {

--- a/website/package.json
+++ b/website/package.json
@@ -42,6 +42,6 @@
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "prettier": "^2.7.1"
+    "prettier": "^2.8.4"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "eslint": "^8.35.0",
     "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-prettier": "^8.5.0",
+    "eslint-config-prettier": "^8.7.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-react": "^7.30.1",

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.1",
+    "@docusaurus/core": "2.3.1",
     "@docusaurus/preset-classic": "2.0.1",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",


### PR DESCRIPTION
- Update to use MQTT based triggers.

Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Breaking change

This may break existing automations based on the older version for IKEA Tradfri E1743 if being used.
A redownload/update/resetup of the ikea_1743.yaml will probably be needed.

## Proposed change\*

Updated IKEA TRÅDFRI On/Off Switch & Dimmer (E1743) controller to additionally use mqtt triggers. 
Original entity sensor.\<DEVICE\>_action triggers will still work if that is how your system is setup.

Added new controller for IKEA RODRET Dimmer (E2202).

Updated light, cover and media_player hooks to add support for IKEA RODRET Dimmer (E2202).

The new 2 controllers should now work with future releases of zigbee2mqtt 2.0.0 if and when triggers are refactored to use mqtt rather than the soon to be depecrated sensor.\<DEVICE\>_action.

## Checklist\*

- [Y] I followed sections of the [Contribution Guidelines](https://github.com/lsismeiro/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [Y] I properly tested proposed changes on my system and confirm that they are working as expected.
- [Y] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
